### PR TITLE
Configure dev and prod datasource credentials

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:postgresql://dpg-d2ioktje5dus73b8gv9g-a.singapore-postgres.render.com:5432/easyreach_db
+    username: easyreach_db_user
+    password: ${DEV_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  datasource:
+    url: jdbc:postgresql://dpg-d2ioktje5dus73b8gv9g-a:5432/easyreach_db
+    username: easyreach_db_user
+    password: ${PROD_DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## Summary
- set Render development and production database URLs
- use environment variable placeholders for database passwords
- ensure PostgreSQL driver class for both profiles

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ca8a20c8832d96525306e5737ea2