### PR TITLE
Add company CRUD endpoints and align company references

### DIFF
--- a/src/main/java/com/easyreach/backend/auth/dto/UserDto.java
+++ b/src/main/java/com/easyreach/backend/auth/dto/UserDto.java
@@ -14,7 +14,7 @@ public class UserDto {
     private String mobileNo;
     private Role role;
     private String name;
-    private Integer companyId;
+    private String companyId;
     private String companyName;
     private String createdBy;
     private String location;

--- a/src/main/java/com/easyreach/backend/auth/entity/User.java
+++ b/src/main/java/com/easyreach/backend/auth/entity/User.java
@@ -40,7 +40,7 @@ public class User implements UserDetails {
 
     private String name;
 
-    private Integer companyId;
+    private String companyId;
 
     private String companyName;
 

--- a/src/main/java/com/easyreach/backend/controllers/CompanyController.java
+++ b/src/main/java/com/easyreach/backend/controllers/CompanyController.java
@@ -1,0 +1,72 @@
+package com.easyreach.backend.controllers;
+
+import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.CompanyDto;
+import com.easyreach.backend.services.CompanyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+public class CompanyController {
+
+    private final CompanyService service;
+
+    @Autowired
+    public CompanyController(CompanyService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/companies")
+    public ResponseEntity<ApiResponse<CompanyDto>> create(@RequestBody CompanyDto dto) {
+        try {
+            CompanyDto created = service.create(dto);
+            return ResponseEntity.ok(ApiResponse.success(created));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure(List.of(e.getMessage())));
+        }
+    }
+
+    @GetMapping("/companies/{id}")
+    public ResponseEntity<ApiResponse<CompanyDto>> get(@PathVariable String id) {
+        CompanyDto dto = service.get(id);
+        if (dto == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(ApiResponse.success(dto));
+    }
+
+    @GetMapping("/companies")
+    public ResponseEntity<ApiResponse<Page<CompanyDto>>> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CompanyDto> result = service.list(pageable);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PutMapping("/companies/{id}")
+    public ResponseEntity<ApiResponse<CompanyDto>> update(@PathVariable String id, @RequestBody CompanyDto dto) {
+        try {
+            CompanyDto updated = service.update(id, dto);
+            if (updated == null) {
+                return ResponseEntity.notFound().build();
+            }
+            return ResponseEntity.ok(ApiResponse.success(updated));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(ApiResponse.failure(List.of(e.getMessage())));
+        }
+    }
+
+    @DeleteMapping("/companies/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable String id) {
+        service.delete(id);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/easyreach/backend/dto/CompanyDto.java
+++ b/src/main/java/com/easyreach/backend/dto/CompanyDto.java
@@ -1,0 +1,27 @@
+package com.easyreach.backend.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+public class CompanyDto {
+    private String uuid;
+    private String companyId;
+    private String companyName;
+    private String companyContactNo;
+    private String companyCoordinates;
+    private String companyLocation;
+    private LocalDate companyRegistrationDate;
+    private String ownerName;
+    private String ownerMobileNo;
+    private String ownerEmailAddress;
+    private LocalDate ownerDOB;
+    private Boolean isActive;
+    private Boolean isSynced;
+    private String createdBy;
+    private LocalDateTime createdAt;
+    private String updatedBy;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/easyreach/backend/entities/Company.java
+++ b/src/main/java/com/easyreach/backend/entities/Company.java
@@ -1,0 +1,57 @@
+package com.easyreach.backend.entities;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "companies")
+public class Company {
+
+    @Id
+    private String uuid;
+
+    @Column(unique = true)
+    private String companyId;
+
+    @Column(nullable = false)
+    private String companyName;
+
+    @Column(nullable = false)
+    private String companyContactNo;
+
+    private String companyCoordinates;
+
+    @Column(nullable = false)
+    private String companyLocation;
+
+    @Column(nullable = false)
+    private LocalDate companyRegistrationDate;
+
+    @Column(nullable = false)
+    private String ownerName;
+
+    @Column(nullable = false)
+    private String ownerMobileNo;
+
+    @Column(nullable = false)
+    private String ownerEmailAddress;
+
+    @Column(nullable = false)
+    private LocalDate ownerDOB;
+
+    private Boolean isActive;
+
+    private Boolean isSynced;
+
+    private String createdBy;
+
+    private LocalDateTime createdAt;
+
+    private String updatedBy;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/easyreach/backend/mappers/CompanyMapper.java
+++ b/src/main/java/com/easyreach/backend/mappers/CompanyMapper.java
@@ -1,0 +1,11 @@
+package com.easyreach.backend.mappers;
+
+import com.easyreach.backend.dto.CompanyDto;
+import com.easyreach.backend.entities.Company;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CompanyMapper {
+    Company toEntity(CompanyDto dto);
+    CompanyDto toDto(Company entity);
+}

--- a/src/main/java/com/easyreach/backend/repositories/CompanyRepository.java
+++ b/src/main/java/com/easyreach/backend/repositories/CompanyRepository.java
@@ -1,0 +1,10 @@
+package com.easyreach.backend.repositories;
+
+import com.easyreach.backend.entities.Company;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CompanyRepository extends JpaRepository<Company, String> {
+    Optional<Company> findByCompanyId(String companyId);
+}

--- a/src/main/java/com/easyreach/backend/services/CompanyService.java
+++ b/src/main/java/com/easyreach/backend/services/CompanyService.java
@@ -1,0 +1,97 @@
+package com.easyreach.backend.services;
+
+import com.easyreach.backend.dto.CompanyDto;
+import com.easyreach.backend.entities.Company;
+import com.easyreach.backend.mappers.CompanyMapper;
+import com.easyreach.backend.repositories.CompanyRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class CompanyService {
+
+    private final CompanyRepository repository;
+    private final CompanyMapper mapper;
+
+    @Autowired
+    public CompanyService(CompanyRepository repository, CompanyMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    public CompanyDto create(CompanyDto dto) {
+        validate(dto);
+        Company entity = mapper.toEntity(dto);
+        LocalDateTime now = LocalDateTime.now();
+        entity.setCreatedAt(now);
+        entity.setUpdatedAt(now);
+        return mapper.toDto(repository.save(entity));
+    }
+
+    public CompanyDto upsert(CompanyDto dto) {
+        validate(dto);
+        Optional<Company> existingOpt = repository.findById(dto.getUuid());
+        if (existingOpt.isPresent()) {
+            Company existing = existingOpt.get();
+            updateEntity(existing, dto);
+            existing.setUpdatedAt(LocalDateTime.now());
+            return mapper.toDto(repository.save(existing));
+        }
+        return create(dto);
+    }
+
+    public CompanyDto get(String id) {
+        return repository.findById(id).map(mapper::toDto).orElse(null);
+    }
+
+    public Page<CompanyDto> list(Pageable pageable) {
+        return repository.findAll(pageable).map(mapper::toDto);
+    }
+
+    public CompanyDto update(String id, CompanyDto dto) {
+        Optional<Company> existingOpt = repository.findById(id);
+        if (existingOpt.isEmpty()) {
+            return null;
+        }
+        Company existing = existingOpt.get();
+        updateEntity(existing, dto);
+        existing.setUpdatedAt(LocalDateTime.now());
+        return mapper.toDto(repository.save(existing));
+    }
+
+    public void delete(String id) {
+        repository.findById(id).ifPresent(entity -> {
+            entity.setIsActive(false);
+            entity.setUpdatedAt(LocalDateTime.now());
+            repository.save(entity);
+        });
+    }
+
+    private void updateEntity(Company existing, CompanyDto dto) {
+        existing.setCompanyId(dto.getCompanyId());
+        existing.setCompanyName(dto.getCompanyName());
+        existing.setCompanyContactNo(dto.getCompanyContactNo());
+        existing.setCompanyCoordinates(dto.getCompanyCoordinates());
+        existing.setCompanyLocation(dto.getCompanyLocation());
+        existing.setCompanyRegistrationDate(dto.getCompanyRegistrationDate());
+        existing.setOwnerName(dto.getOwnerName());
+        existing.setOwnerMobileNo(dto.getOwnerMobileNo());
+        existing.setOwnerEmailAddress(dto.getOwnerEmailAddress());
+        existing.setOwnerDOB(dto.getOwnerDOB());
+        existing.setIsActive(dto.getIsActive());
+        existing.setIsSynced(dto.getIsSynced());
+        existing.setCreatedBy(dto.getCreatedBy());
+        existing.setUpdatedBy(dto.getUpdatedBy());
+    }
+
+    private void validate(CompanyDto dto) {
+        if (dto.getUuid() == null || dto.getCompanyId() == null) {
+            throw new IllegalArgumentException("uuid and companyId are required");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS users (
   password VARCHAR(255),
   role VARCHAR(30),
   name VARCHAR(100),
-  companyId INTEGER,
+  companyId VARCHAR(50),
   companyName VARCHAR(100),
   createdBy VARCHAR(50),
   location VARCHAR(100),

--- a/src/test/java/com/easyreach/companies/CompanyServiceTest.java
+++ b/src/test/java/com/easyreach/companies/CompanyServiceTest.java
@@ -1,0 +1,48 @@
+package com.easyreach.companies;
+
+import com.easyreach.backend.dto.CompanyDto;
+import com.easyreach.backend.repositories.CompanyRepository;
+import com.easyreach.backend.services.CompanyService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class CompanyServiceTest {
+
+    @Autowired
+    private CompanyService service;
+
+    @Autowired
+    private CompanyRepository repository;
+
+    @Test
+    void upsertCreatesAndUpdates() {
+        CompanyDto dto = new CompanyDto();
+        dto.setUuid("u1");
+        dto.setCompanyId("c1");
+        dto.setCompanyName("Comp1");
+        dto.setCompanyContactNo("123");
+        dto.setCompanyLocation("Loc");
+        dto.setCompanyRegistrationDate(LocalDate.now());
+        dto.setOwnerName("Owner");
+        dto.setOwnerMobileNo("999");
+        dto.setOwnerEmailAddress("owner@example.com");
+        dto.setOwnerDOB(LocalDate.now());
+
+        CompanyDto created = service.upsert(dto);
+        assertThat(created.getCompanyName()).isEqualTo("Comp1");
+        assertThat(repository.count()).isEqualTo(1);
+
+        dto.setCompanyName("Comp2");
+        CompanyDto updated = service.upsert(dto);
+        assertThat(updated.getCompanyName()).isEqualTo("Comp2");
+        assertThat(repository.count()).isEqualTo(1);
+    }
+}

--- a/src/test/java/com/easyreach/companies/CompanyValidationTest.java
+++ b/src/test/java/com/easyreach/companies/CompanyValidationTest.java
@@ -1,0 +1,23 @@
+package com.easyreach.companies;
+
+import com.easyreach.backend.dto.CompanyDto;
+import com.easyreach.backend.services.CompanyService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class CompanyValidationTest {
+
+    @Autowired
+    private CompanyService service;
+
+    @Test
+    void missingRequiredFields() {
+        CompanyDto dto = new CompanyDto();
+        assertThatThrownBy(() -> service.upsert(dto))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- add Company entity, DTO, mapper, repository, service and controller for CRUD operations
- switch user companyId to string and update initial migration accordingly
- cover company service with basic tests

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b29e6e30fc832d8f8c5b692ea7fce7