### PR TITLE
Preserve camelCase DB column names

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: none
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: false
   flyway:
     enabled: true


### PR DESCRIPTION
## Summary
- Configure Hibernate to use `PhysicalNamingStrategyStandardImpl` so entity fields map to camelCase database columns without extra annotations.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*
- `mvn -q spring-boot:run` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a7a3a71c832dbee974aef07f8f9f