### PR TITLE
Use integers for CompanyDto status flags

### DIFF
--- a/src/main/java/com/easyreach/backend/dto/CompanyDto.java
+++ b/src/main/java/com/easyreach/backend/dto/CompanyDto.java
@@ -18,8 +18,8 @@ public class CompanyDto {
     private String ownerMobileNo;
     private String ownerEmailAddress;
     private LocalDate ownerDOB;
-    private Boolean isActive;
-    private Boolean isSynced;
+    private Integer isActive = 1;
+    private Integer isSynced = 0;
     private String createdBy;
     private LocalDateTime createdAt;
     private String updatedBy;


### PR DESCRIPTION
## Summary
- represent CompanyDto's activity and sync flags as integers with defaults matching DB values

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab309bf0832da18f46e8b78080a1