### PR TITLE
Use integer flags for company activation and sync

### DIFF
--- a/src/main/java/com/easyreach/backend/dto/CompanyDto.java
+++ b/src/main/java/com/easyreach/backend/dto/CompanyDto.java
@@ -18,8 +18,8 @@ public class CompanyDto {
     private String ownerMobileNo;
     private String ownerEmailAddress;
     private LocalDate ownerDOB;
-    private Boolean isActive;
-    private Boolean isSynced;
+    private Integer isActive;
+    private Integer isSynced;
     private String createdBy;
     private LocalDateTime createdAt;
     private String updatedBy;

--- a/src/main/java/com/easyreach/backend/entities/Company.java
+++ b/src/main/java/com/easyreach/backend/entities/Company.java
@@ -43,9 +43,11 @@ public class Company {
     @Column(nullable = false)
     private LocalDate ownerDOB;
 
-    private Boolean isActive;
+    @Column(columnDefinition = "INTEGER DEFAULT 1")
+    private Integer isActive;
 
-    private Boolean isSynced;
+    @Column(columnDefinition = "INTEGER DEFAULT 0")
+    private Integer isSynced;
 
     private String createdBy;
 

--- a/src/main/java/com/easyreach/backend/services/CompanyService.java
+++ b/src/main/java/com/easyreach/backend/services/CompanyService.java
@@ -30,6 +30,12 @@ public class CompanyService {
         LocalDateTime now = LocalDateTime.now();
         entity.setCreatedAt(now);
         entity.setUpdatedAt(now);
+        if (entity.getIsActive() == null) {
+            entity.setIsActive(1);
+        }
+        if (entity.getIsSynced() == null) {
+            entity.setIsSynced(0);
+        }
         return mapper.toDto(repository.save(entity));
     }
 
@@ -66,7 +72,7 @@ public class CompanyService {
 
     public void delete(String id) {
         repository.findById(id).ifPresent(entity -> {
-            entity.setIsActive(false);
+            entity.setIsActive(0);
             entity.setUpdatedAt(LocalDateTime.now());
             repository.save(entity);
         });


### PR DESCRIPTION
## Summary
- change Company entity isActive/isSynced to integer flags
- use integer defaults in Company DTO and service
- ensure delete uses 0/1 values and set defaults on create

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab350dfc832d8e31f83626619914