### PR TITLE
Use integer flags instead of booleans

### DIFF
--- a/src/main/java/com/easyreach/backend/auth/service/AuthService.java
+++ b/src/main/java/com/easyreach/backend/auth/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(Role.USER)
-                .isActive(true)
+                .isActive(1)
                 .build();
         userRepository.save(user);
         return createTokens(user, null);

--- a/src/main/java/com/easyreach/backend/services/CompanyService.java
+++ b/src/main/java/com/easyreach/backend/services/CompanyService.java
@@ -66,7 +66,7 @@ public class CompanyService {
 
     public void delete(String id) {
         repository.findById(id).ifPresent(entity -> {
-            entity.setIsActive(false);
+            entity.setIsActive(0);
             entity.setUpdatedAt(LocalDateTime.now());
             repository.save(entity);
         });


### PR DESCRIPTION
## Summary
- replace boolean `isActive` flags with integer values in services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab39c584832da8d4160e5cf1ec55