### PR TITLE
Use integer isActive in UserDto

### DIFF
--- a/src/main/java/com/easyreach/backend/auth/dto/UserDto.java
+++ b/src/main/java/com/easyreach/backend/auth/dto/UserDto.java
@@ -20,5 +20,5 @@ public class UserDto {
     private String location;
     private LocalDate dateOfBirth;
     private LocalDate joiningDate;
-    private Boolean isActive;
+    private Integer isActive;
 }

--- a/src/main/java/com/easyreach/backend/auth/mapper/UserMapper.java
+++ b/src/main/java/com/easyreach/backend/auth/mapper/UserMapper.java
@@ -3,9 +3,13 @@ package com.easyreach.backend.auth.mapper;
 import com.easyreach.backend.auth.dto.UserDto;
 import com.easyreach.backend.auth.entity.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
+    @Mapping(target = "isActive", expression = "java(dto.getIsActive() == null ? null : dto.getIsActive() == 1)")
     User toEntity(UserDto dto);
+
+    @Mapping(target = "isActive", expression = "java(entity.getIsActive() == null ? null : (entity.getIsActive() ? 1 : 0))")
     UserDto toDto(User entity);
 }

--- a/src/main/java/com/easyreach/backend/auth/service/UserService.java
+++ b/src/main/java/com/easyreach/backend/auth/service/UserService.java
@@ -56,7 +56,7 @@ public class UserService {
         existing.setLocation(dto.getLocation());
         existing.setDateOfBirth(dto.getDateOfBirth());
         existing.setJoiningDate(dto.getJoiningDate());
-        existing.setIsActive(dto.getIsActive());
+        existing.setIsActive(dto.getIsActive() == null ? null : dto.getIsActive() == 1);
         return mapper.toDto(repository.save(existing));
     }
 


### PR DESCRIPTION
## Summary
- represent `isActive` in `UserDto` as `Integer`
- add MapStruct conversions between 0/1 integers and Boolean
- convert `UserService` update logic to handle 0/1 values

## Testing
- `mvn -q -ntp -e test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab3c5fa8832dab98df65d5534f56