### PR TITLE
Use integer literal for user active flag

### DIFF
--- a/src/main/java/com/easyreach/backend/auth/service/AuthService.java
+++ b/src/main/java/com/easyreach/backend/auth/service/AuthService.java
@@ -40,7 +40,7 @@ public class AuthService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(Role.USER)
-                .isActive(true)
+                .isActive(1)
                 .build();
         userRepository.save(user);
         return createTokens(user, null);


### PR DESCRIPTION
## Summary
- set new users as active using `1` instead of boolean

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.easyreach:easyreach-backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab4914a8832db0483cae424648c0