### PR TITLE
Switch User isActive field to Integer

### DIFF
--- a/src/main/java/com/easyreach/backend/auth/entity/User.java
+++ b/src/main/java/com/easyreach/backend/auth/entity/User.java
@@ -52,7 +52,7 @@ public class User implements UserDetails {
 
     private LocalDate joiningDate;
 
-    private Boolean isActive;
+    private Integer isActive;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/com/easyreach/backend/auth/mapper/UserMapper.java
+++ b/src/main/java/com/easyreach/backend/auth/mapper/UserMapper.java
@@ -3,13 +3,10 @@ package com.easyreach.backend.auth.mapper;
 import com.easyreach.backend.auth.dto.UserDto;
 import com.easyreach.backend.auth.entity.User;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
-    @Mapping(target = "isActive", expression = "java(dto.getIsActive() == null ? null : dto.getIsActive() == 1)")
     User toEntity(UserDto dto);
 
-    @Mapping(target = "isActive", expression = "java(entity.getIsActive() == null ? null : (entity.getIsActive() ? 1 : 0))")
     UserDto toDto(User entity);
 }

--- a/src/main/java/com/easyreach/backend/auth/service/UserService.java
+++ b/src/main/java/com/easyreach/backend/auth/service/UserService.java
@@ -27,6 +27,9 @@ public class UserService {
         if (dto.getId() == null) {
             throw new IllegalArgumentException("id is required");
         }
+        if (dto.getIsActive() == null) {
+            dto.setIsActive(1);
+        }
         User entity = mapper.toEntity(dto);
         return mapper.toDto(repository.save(entity));
     }
@@ -56,7 +59,7 @@ public class UserService {
         existing.setLocation(dto.getLocation());
         existing.setDateOfBirth(dto.getDateOfBirth());
         existing.setJoiningDate(dto.getJoiningDate());
-        existing.setIsActive(dto.getIsActive() == null ? null : dto.getIsActive() == 1);
+        existing.setIsActive(dto.getIsActive() == null ? 1 : dto.getIsActive());
         return mapper.toDto(repository.save(existing));
     }
 


### PR DESCRIPTION
## Summary
- use `Integer` for user `isActive` status
- simplify user mapper to rely on default mapping
- handle `isActive` defaulting in user service

## Testing
- `mvn -e clean compile` *(fails: Non-resolvable parent POM)*
- `mvn -e test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b18c544c832dae2238e361e61852