### PR TITLE
feat: add bulk sync endpoint

### DIFF
--- a/src/main/java/com/easyreach/backend/controller/SyncController.java
+++ b/src/main/java/com/easyreach/backend/controller/SyncController.java
@@ -1,0 +1,67 @@
+package com.easyreach.backend.controller;
+
+import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.SyncRequestDto;
+import com.easyreach.backend.dto.SyncResponseDto;
+import com.easyreach.backend.service.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "Sync")
+public class SyncController {
+    private final CompanyService companyService;
+    private final DailyExpenseService dailyExpenseService;
+    private final DieselUsageService dieselUsageService;
+    private final EquipmentUsageService equipmentUsageService;
+    private final ExpenseMasterService expenseMasterService;
+    private final InternalVehicleService internalVehicleService;
+    private final PayerService payerService;
+    private final PayerSettlementService payerSettlementService;
+    private final VehicleEntryService vehicleEntryService;
+    private final VehicleTypeService vehicleTypeService;
+
+    @PostMapping("/sync")
+    @Operation(summary = "Bulk synchronize entities", description = "Accepts lists of entity DTOs and persists them with isSynced=true")
+    public ResponseEntity<ApiResponse<SyncResponseDto>> sync(@Valid @RequestBody SyncRequestDto request) {
+        SyncResponseDto response = new SyncResponseDto();
+        if (request.getCompanies() != null && !request.getCompanies().isEmpty()) {
+            response.setCompanies(companyService.bulkSync(request.getCompanies()));
+        }
+        if (request.getDailyExpenses() != null && !request.getDailyExpenses().isEmpty()) {
+            response.setDailyExpenses(dailyExpenseService.bulkSync(request.getDailyExpenses()));
+        }
+        if (request.getDieselUsages() != null && !request.getDieselUsages().isEmpty()) {
+            response.setDieselUsages(dieselUsageService.bulkSync(request.getDieselUsages()));
+        }
+        if (request.getEquipmentUsages() != null && !request.getEquipmentUsages().isEmpty()) {
+            response.setEquipmentUsages(equipmentUsageService.bulkSync(request.getEquipmentUsages()));
+        }
+        if (request.getExpenseMasters() != null && !request.getExpenseMasters().isEmpty()) {
+            response.setExpenseMasters(expenseMasterService.bulkSync(request.getExpenseMasters()));
+        }
+        if (request.getInternalVehicles() != null && !request.getInternalVehicles().isEmpty()) {
+            response.setInternalVehicles(internalVehicleService.bulkSync(request.getInternalVehicles()));
+        }
+        if (request.getPayers() != null && !request.getPayers().isEmpty()) {
+            response.setPayers(payerService.bulkSync(request.getPayers()));
+        }
+        if (request.getPayerSettlements() != null && !request.getPayerSettlements().isEmpty()) {
+            response.setPayerSettlements(payerSettlementService.bulkSync(request.getPayerSettlements()));
+        }
+        if (request.getVehicleEntries() != null && !request.getVehicleEntries().isEmpty()) {
+            response.setVehicleEntries(vehicleEntryService.bulkSync(request.getVehicleEntries()));
+        }
+        if (request.getVehicleTypes() != null && !request.getVehicleTypes().isEmpty()) {
+            response.setVehicleTypes(vehicleTypeService.bulkSync(request.getVehicleTypes()));
+        }
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}
+

--- a/src/main/java/com/easyreach/backend/dto/SyncRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/SyncRequestDto.java
@@ -1,0 +1,43 @@
+package com.easyreach.backend.dto;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import com.easyreach.backend.dto.companies.CompanyRequestDto;
+import com.easyreach.backend.dto.daily_expenses.DailyExpenseRequestDto;
+import com.easyreach.backend.dto.diesel_usage.DieselUsageRequestDto;
+import com.easyreach.backend.dto.equipment_usage.EquipmentUsageRequestDto;
+import com.easyreach.backend.dto.expense_master.ExpenseMasterRequestDto;
+import com.easyreach.backend.dto.internal_vehicles.InternalVehicleRequestDto;
+import com.easyreach.backend.dto.payers.PayerRequestDto;
+import com.easyreach.backend.dto.payer_settlements.PayerSettlementRequestDto;
+import com.easyreach.backend.dto.vehicle_entries.VehicleEntryRequestDto;
+import com.easyreach.backend.dto.vehicle_types.VehicleTypeRequestDto;
+
+import lombok.Data;
+
+@Data
+public class SyncRequestDto {
+    @Valid
+    private List<CompanyRequestDto> companies;
+    @Valid
+    private List<DailyExpenseRequestDto> dailyExpenses;
+    @Valid
+    private List<DieselUsageRequestDto> dieselUsages;
+    @Valid
+    private List<EquipmentUsageRequestDto> equipmentUsages;
+    @Valid
+    private List<ExpenseMasterRequestDto> expenseMasters;
+    @Valid
+    private List<InternalVehicleRequestDto> internalVehicles;
+    @Valid
+    private List<PayerRequestDto> payers;
+    @Valid
+    private List<PayerSettlementRequestDto> payerSettlements;
+    @Valid
+    private List<VehicleEntryRequestDto> vehicleEntries;
+    @Valid
+    private List<VehicleTypeRequestDto> vehicleTypes;
+}
+

--- a/src/main/java/com/easyreach/backend/dto/SyncResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/SyncResponseDto.java
@@ -1,0 +1,22 @@
+package com.easyreach.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SyncResponseDto {
+    private int companies;
+    private int dailyExpenses;
+    private int dieselUsages;
+    private int equipmentUsages;
+    private int expenseMasters;
+    private int internalVehicles;
+    private int payers;
+    private int payerSettlements;
+    private int vehicleEntries;
+    private int vehicleTypes;
+}
+

--- a/src/main/java/com/easyreach/backend/service/CompanyService.java
+++ b/src/main/java/com/easyreach/backend/service/CompanyService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.companies.CompanyResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface CompanyService {
     ApiResponse<CompanyResponseDto> create(CompanyRequestDto dto);
     ApiResponse<CompanyResponseDto> update(String id, CompanyRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<CompanyResponseDto> get(String id);
     ApiResponse<Page<CompanyResponseDto>> list(Pageable pageable);
+    int bulkSync(List<CompanyRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/DailyExpenseService.java
+++ b/src/main/java/com/easyreach/backend/service/DailyExpenseService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.daily_expenses.DailyExpenseResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface DailyExpenseService {
     ApiResponse<DailyExpenseResponseDto> create(DailyExpenseRequestDto dto);
     ApiResponse<DailyExpenseResponseDto> update(String id, DailyExpenseRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<DailyExpenseResponseDto> get(String id);
     ApiResponse<Page<DailyExpenseResponseDto>> list(Pageable pageable);
+    int bulkSync(List<DailyExpenseRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/DieselUsageService.java
+++ b/src/main/java/com/easyreach/backend/service/DieselUsageService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.diesel_usage.DieselUsageResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface DieselUsageService {
     ApiResponse<DieselUsageResponseDto> create(DieselUsageRequestDto dto);
     ApiResponse<DieselUsageResponseDto> update(String id, DieselUsageRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<DieselUsageResponseDto> get(String id);
     ApiResponse<Page<DieselUsageResponseDto>> list(Pageable pageable);
+    int bulkSync(List<DieselUsageRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/EquipmentUsageService.java
+++ b/src/main/java/com/easyreach/backend/service/EquipmentUsageService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.equipment_usage.EquipmentUsageResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface EquipmentUsageService {
     ApiResponse<EquipmentUsageResponseDto> create(EquipmentUsageRequestDto dto);
     ApiResponse<EquipmentUsageResponseDto> update(String id, EquipmentUsageRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<EquipmentUsageResponseDto> get(String id);
     ApiResponse<Page<EquipmentUsageResponseDto>> list(Pageable pageable);
+    int bulkSync(List<EquipmentUsageRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/ExpenseMasterService.java
+++ b/src/main/java/com/easyreach/backend/service/ExpenseMasterService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.expense_master.ExpenseMasterResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ExpenseMasterService {
     ApiResponse<ExpenseMasterResponseDto> create(ExpenseMasterRequestDto dto);
     ApiResponse<ExpenseMasterResponseDto> update(String id, ExpenseMasterRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<ExpenseMasterResponseDto> get(String id);
     ApiResponse<Page<ExpenseMasterResponseDto>> list(Pageable pageable);
+    int bulkSync(List<ExpenseMasterRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/InternalVehicleService.java
+++ b/src/main/java/com/easyreach/backend/service/InternalVehicleService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.internal_vehicles.InternalVehicleResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface InternalVehicleService {
     ApiResponse<InternalVehicleResponseDto> create(InternalVehicleRequestDto dto);
     ApiResponse<InternalVehicleResponseDto> update(String id, InternalVehicleRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<InternalVehicleResponseDto> get(String id);
     ApiResponse<Page<InternalVehicleResponseDto>> list(Pageable pageable);
+    int bulkSync(List<InternalVehicleRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/PayerService.java
+++ b/src/main/java/com/easyreach/backend/service/PayerService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.payers.PayerResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PayerService {
     ApiResponse<PayerResponseDto> create(PayerRequestDto dto);
     ApiResponse<PayerResponseDto> update(String id, PayerRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<PayerResponseDto> get(String id);
     ApiResponse<Page<PayerResponseDto>> list(Pageable pageable);
+    int bulkSync(List<PayerRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/PayerSettlementService.java
+++ b/src/main/java/com/easyreach/backend/service/PayerSettlementService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.payer_settlements.PayerSettlementResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PayerSettlementService {
     ApiResponse<PayerSettlementResponseDto> create(PayerSettlementRequestDto dto);
     ApiResponse<PayerSettlementResponseDto> update(String id, PayerSettlementRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<PayerSettlementResponseDto> get(String id);
     ApiResponse<Page<PayerSettlementResponseDto>> list(Pageable pageable);
+    int bulkSync(List<PayerSettlementRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/VehicleEntryService.java
+++ b/src/main/java/com/easyreach/backend/service/VehicleEntryService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.vehicle_entries.VehicleEntryResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface VehicleEntryService {
     ApiResponse<VehicleEntryResponseDto> create(VehicleEntryRequestDto dto);
     ApiResponse<VehicleEntryResponseDto> update(String id, VehicleEntryRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<VehicleEntryResponseDto> get(String id);
     ApiResponse<Page<VehicleEntryResponseDto>> list(Pageable pageable);
+    int bulkSync(List<VehicleEntryRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/VehicleTypeService.java
+++ b/src/main/java/com/easyreach/backend/service/VehicleTypeService.java
@@ -6,10 +6,13 @@ import com.easyreach.backend.dto.vehicle_types.VehicleTypeResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface VehicleTypeService {
     ApiResponse<VehicleTypeResponseDto> create(VehicleTypeRequestDto dto);
     ApiResponse<VehicleTypeResponseDto> update(String id, VehicleTypeRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<VehicleTypeResponseDto> get(String id);
     ApiResponse<Page<VehicleTypeResponseDto>> list(Pageable pageable);
+    int bulkSync(List<VehicleTypeRequestDto> dtos);
 }

--- a/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class CompanyServiceImpl implements CompanyService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<CompanyResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<CompanyRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<Company> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<DailyExpenseResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<DailyExpenseRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<DailyExpense> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/DieselUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DieselUsageServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class DieselUsageServiceImpl implements DieselUsageService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<DieselUsageResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<DieselUsageRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<DieselUsage> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<EquipmentUsageResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<EquipmentUsageRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<EquipmentUsage> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<ExpenseMasterResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<ExpenseMasterRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<ExpenseMaster> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class InternalVehicleServiceImpl implements InternalVehicleService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<InternalVehicleResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<InternalVehicleRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<InternalVehicle> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class PayerServiceImpl implements PayerService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<PayerResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<PayerRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<Payer> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class PayerSettlementServiceImpl implements PayerSettlementService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<PayerSettlementResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<PayerSettlementRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<PayerSettlement> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class VehicleEntryServiceImpl implements VehicleEntryService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<VehicleEntryResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<VehicleEntryRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<VehicleEntry> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -52,5 +54,16 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
     @Transactional(readOnly = true)
     public ApiResponse<Page<VehicleTypeResponseDto>> list(Pageable pageable) {
         return ApiResponse.success(repository.findAll(pageable).map(mapper::toDto));
+    }
+
+    @Override
+    public int bulkSync(List<VehicleTypeRequestDto> dtos) {
+        if (dtos == null || dtos.isEmpty()) return 0;
+        List<VehicleType> entities = dtos.stream()
+                .map(mapper::toEntity)
+                .peek(e -> e.setIsSynced(true))
+                .toList();
+        repository.saveAll(entities);
+        return entities.size();
     }
 }


### PR DESCRIPTION
## Summary
- add SyncRequestDto/SyncResponseDto for aggregating multi-entity sync payloads
- implement SyncController with POST /api/sync for bulk synchronization
- extend domain services with bulkSync operations that mark records as synced

## Testing
- `mvn -q -e test` *(fails: Network is unreachable to maven central)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e3126cfc832d826b3ccf11e2f93c