### PR TITLE
Implement deduplicated bulk sync with merging

### DIFF
--- a/src/main/java/com/easyreach/backend/mapper/CompanyMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/CompanyMapper.java
@@ -12,4 +12,7 @@ public interface CompanyMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget Company entity, CompanyRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(CompanyRequestDto dto, @MappingTarget Company entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/DailyExpenseMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/DailyExpenseMapper.java
@@ -12,4 +12,7 @@ public interface DailyExpenseMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget DailyExpense entity, DailyExpenseRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(DailyExpenseRequestDto dto, @MappingTarget DailyExpense entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/DieselUsageMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/DieselUsageMapper.java
@@ -12,4 +12,7 @@ public interface DieselUsageMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget DieselUsage entity, DieselUsageRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(DieselUsageRequestDto dto, @MappingTarget DieselUsage entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/EquipmentUsageMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/EquipmentUsageMapper.java
@@ -12,4 +12,7 @@ public interface EquipmentUsageMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget EquipmentUsage entity, EquipmentUsageRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(EquipmentUsageRequestDto dto, @MappingTarget EquipmentUsage entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/ExpenseMasterMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/ExpenseMasterMapper.java
@@ -12,4 +12,7 @@ public interface ExpenseMasterMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget ExpenseMaster entity, ExpenseMasterRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(ExpenseMasterRequestDto dto, @MappingTarget ExpenseMaster entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/InternalVehicleMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/InternalVehicleMapper.java
@@ -12,4 +12,7 @@ public interface InternalVehicleMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget InternalVehicle entity, InternalVehicleRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(InternalVehicleRequestDto dto, @MappingTarget InternalVehicle entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/PayerMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/PayerMapper.java
@@ -12,4 +12,7 @@ public interface PayerMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget Payer entity, PayerRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(PayerRequestDto dto, @MappingTarget Payer entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/PayerSettlementMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/PayerSettlementMapper.java
@@ -12,4 +12,7 @@ public interface PayerSettlementMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget PayerSettlement entity, PayerSettlementRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(PayerSettlementRequestDto dto, @MappingTarget PayerSettlement entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/VehicleEntryMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/VehicleEntryMapper.java
@@ -12,4 +12,7 @@ public interface VehicleEntryMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget VehicleEntry entity, VehicleEntryRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(VehicleEntryRequestDto dto, @MappingTarget VehicleEntry entity);
 }

--- a/src/main/java/com/easyreach/backend/mapper/VehicleTypeMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/VehicleTypeMapper.java
@@ -12,4 +12,7 @@ public interface VehicleTypeMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     void update(@MappingTarget VehicleType entity, VehicleTypeRequestDto dto);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void merge(VehicleTypeRequestDto dto, @MappingTarget VehicleType entity);
 }

--- a/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +62,31 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
     @Override
     public int bulkSync(List<DailyExpenseRequestDto> dtos) {
         if (dtos == null || dtos.isEmpty()) return 0;
-        List<DailyExpense> entities = dtos.stream()
-                .map(mapper::toEntity)
-                .peek(e -> e.setIsSynced(true))
-                .toList();
+        Map<String, DailyExpenseRequestDto> dtoMap = dtos.stream()
+                .filter(d -> d.getExpenseId() != null)
+                .collect(Collectors.toMap(DailyExpenseRequestDto::getExpenseId, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (dtoMap.isEmpty()) return 0;
+
+        Map<String, DailyExpense> existing = repository.findAllById(dtoMap.keySet()).stream()
+                .collect(Collectors.toMap(DailyExpense::getExpenseId, Function.identity()));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<DailyExpense> entities = new ArrayList<>();
+        for (DailyExpenseRequestDto dto : dtoMap.values()) {
+            DailyExpense entity = existing.get(dto.getExpenseId());
+            if (entity != null) {
+                mapper.merge(dto, entity);
+                entity.setUpdatedAt(now);
+                entity.setIsSynced(true);
+                entities.add(entity);
+            } else {
+                DailyExpense e = mapper.toEntity(dto);
+                e.setCreatedAt(now);
+                e.setUpdatedAt(now);
+                e.setIsSynced(true);
+                entities.add(e);
+            }
+        }
         repository.saveAll(entities);
         return entities.size();
     }

--- a/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +62,31 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
     @Override
     public int bulkSync(List<EquipmentUsageRequestDto> dtos) {
         if (dtos == null || dtos.isEmpty()) return 0;
-        List<EquipmentUsage> entities = dtos.stream()
-                .map(mapper::toEntity)
-                .peek(e -> e.setIsSynced(true))
-                .toList();
+        Map<String, EquipmentUsageRequestDto> dtoMap = dtos.stream()
+                .filter(d -> d.getEquipmentUsageId() != null)
+                .collect(Collectors.toMap(EquipmentUsageRequestDto::getEquipmentUsageId, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (dtoMap.isEmpty()) return 0;
+
+        Map<String, EquipmentUsage> existing = repository.findAllById(dtoMap.keySet()).stream()
+                .collect(Collectors.toMap(EquipmentUsage::getEquipmentUsageId, Function.identity()));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<EquipmentUsage> entities = new ArrayList<>();
+        for (EquipmentUsageRequestDto dto : dtoMap.values()) {
+            EquipmentUsage entity = existing.get(dto.getEquipmentUsageId());
+            if (entity != null) {
+                mapper.merge(dto, entity);
+                entity.setUpdatedAt(now);
+                entity.setIsSynced(true);
+                entities.add(entity);
+            } else {
+                EquipmentUsage e = mapper.toEntity(dto);
+                e.setCreatedAt(now);
+                e.setUpdatedAt(now);
+                e.setIsSynced(true);
+                entities.add(e);
+            }
+        }
         repository.saveAll(entities);
         return entities.size();
     }

--- a/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +62,31 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
     @Override
     public int bulkSync(List<ExpenseMasterRequestDto> dtos) {
         if (dtos == null || dtos.isEmpty()) return 0;
-        List<ExpenseMaster> entities = dtos.stream()
-                .map(mapper::toEntity)
-                .peek(e -> e.setIsSynced(true))
-                .toList();
+        Map<String, ExpenseMasterRequestDto> dtoMap = dtos.stream()
+                .filter(d -> d.getId() != null)
+                .collect(Collectors.toMap(ExpenseMasterRequestDto::getId, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (dtoMap.isEmpty()) return 0;
+
+        Map<String, ExpenseMaster> existing = repository.findAllById(dtoMap.keySet()).stream()
+                .collect(Collectors.toMap(ExpenseMaster::getId, Function.identity()));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<ExpenseMaster> entities = new ArrayList<>();
+        for (ExpenseMasterRequestDto dto : dtoMap.values()) {
+            ExpenseMaster entity = existing.get(dto.getId());
+            if (entity != null) {
+                mapper.merge(dto, entity);
+                entity.setUpdatedAt(now);
+                entity.setIsSynced(true);
+                entities.add(entity);
+            } else {
+                ExpenseMaster e = mapper.toEntity(dto);
+                e.setCreatedAt(now);
+                e.setUpdatedAt(now);
+                e.setIsSynced(true);
+                entities.add(e);
+            }
+        }
         repository.saveAll(entities);
         return entities.size();
     }

--- a/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +62,31 @@ public class InternalVehicleServiceImpl implements InternalVehicleService {
     @Override
     public int bulkSync(List<InternalVehicleRequestDto> dtos) {
         if (dtos == null || dtos.isEmpty()) return 0;
-        List<InternalVehicle> entities = dtos.stream()
-                .map(mapper::toEntity)
-                .peek(e -> e.setIsSynced(true))
-                .toList();
+        Map<String, InternalVehicleRequestDto> dtoMap = dtos.stream()
+                .filter(d -> d.getVehicleId() != null)
+                .collect(Collectors.toMap(InternalVehicleRequestDto::getVehicleId, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (dtoMap.isEmpty()) return 0;
+
+        Map<String, InternalVehicle> existing = repository.findAllById(dtoMap.keySet()).stream()
+                .collect(Collectors.toMap(InternalVehicle::getVehicleId, Function.identity()));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<InternalVehicle> entities = new ArrayList<>();
+        for (InternalVehicleRequestDto dto : dtoMap.values()) {
+            InternalVehicle entity = existing.get(dto.getVehicleId());
+            if (entity != null) {
+                mapper.merge(dto, entity);
+                entity.setUpdatedAt(now);
+                entity.setIsSynced(true);
+                entities.add(entity);
+            } else {
+                InternalVehicle e = mapper.toEntity(dto);
+                e.setCreatedAt(now);
+                e.setUpdatedAt(now);
+                e.setIsSynced(true);
+                entities.add(e);
+            }
+        }
         repository.saveAll(entities);
         return entities.size();
     }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +62,31 @@ public class PayerServiceImpl implements PayerService {
     @Override
     public int bulkSync(List<PayerRequestDto> dtos) {
         if (dtos == null || dtos.isEmpty()) return 0;
-        List<Payer> entities = dtos.stream()
-                .map(mapper::toEntity)
-                .peek(e -> e.setIsSynced(true))
-                .toList();
+        Map<String, PayerRequestDto> dtoMap = dtos.stream()
+                .filter(d -> d.getPayerId() != null)
+                .collect(Collectors.toMap(PayerRequestDto::getPayerId, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (dtoMap.isEmpty()) return 0;
+
+        Map<String, Payer> existing = repository.findAllById(dtoMap.keySet()).stream()
+                .collect(Collectors.toMap(Payer::getPayerId, Function.identity()));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<Payer> entities = new ArrayList<>();
+        for (PayerRequestDto dto : dtoMap.values()) {
+            Payer entity = existing.get(dto.getPayerId());
+            if (entity != null) {
+                mapper.merge(dto, entity);
+                entity.setUpdatedAt(now);
+                entity.setIsSynced(true);
+                entities.add(entity);
+            } else {
+                Payer e = mapper.toEntity(dto);
+                e.setCreatedAt(now);
+                e.setUpdatedAt(now);
+                e.setIsSynced(true);
+                entities.add(e);
+            }
+        }
         repository.saveAll(entities);
         return entities.size();
     }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
@@ -14,7 +14,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,10 +62,31 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
     @Override
     public int bulkSync(List<VehicleTypeRequestDto> dtos) {
         if (dtos == null || dtos.isEmpty()) return 0;
-        List<VehicleType> entities = dtos.stream()
-                .map(mapper::toEntity)
-                .peek(e -> e.setIsSynced(true))
-                .toList();
+        Map<String, VehicleTypeRequestDto> dtoMap = dtos.stream()
+                .filter(d -> d.getId() != null)
+                .collect(Collectors.toMap(VehicleTypeRequestDto::getId, Function.identity(), (a, b) -> b, LinkedHashMap::new));
+        if (dtoMap.isEmpty()) return 0;
+
+        Map<String, VehicleType> existing = repository.findAllById(dtoMap.keySet()).stream()
+                .collect(Collectors.toMap(VehicleType::getId, Function.identity()));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        List<VehicleType> entities = new ArrayList<>();
+        for (VehicleTypeRequestDto dto : dtoMap.values()) {
+            VehicleType entity = existing.get(dto.getId());
+            if (entity != null) {
+                mapper.merge(dto, entity);
+                entity.setUpdatedAt(now);
+                entity.setIsSynced(true);
+                entities.add(entity);
+            } else {
+                VehicleType e = mapper.toEntity(dto);
+                e.setCreatedAt(now);
+                e.setUpdatedAt(now);
+                e.setIsSynced(true);
+                entities.add(e);
+            }
+        }
         repository.saveAll(entities);
         return entities.size();
     }

--- a/src/test/java/com/easyreach/backend/service/CompanyServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/CompanyServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.companies.CompanyRequestDto;
+import com.easyreach.backend.entity.Company;
+import com.easyreach.backend.mapper.CompanyMapper;
+import com.easyreach.backend.repository.CompanyRepository;
+import com.easyreach.backend.service.impl.CompanyServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CompanyServiceImplTest {
+
+    @Mock
+    private CompanyRepository repository;
+    @Mock
+    private CompanyMapper mapper;
+
+    private CompanyServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CompanyServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        CompanyRequestDto d1 = new CompanyRequestDto();
+        d1.setUuid("u1");
+        CompanyRequestDto d1dup = new CompanyRequestDto();
+        d1dup.setUuid("u1");
+        CompanyRequestDto d2 = new CompanyRequestDto();
+        d2.setUuid("u2");
+
+        Company existing = new Company();
+        existing.setUuid("u1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        Company newEntity = new Company();
+        newEntity.setUuid("u2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<Company>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<Company> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, Company> map = saved.stream().collect(java.util.stream.Collectors.toMap(Company::getUuid, c -> c));
+
+        Company savedExisting = map.get("u1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        Company savedNew = map.get("u2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/DailyExpenseServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/DailyExpenseServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.daily_expenses.DailyExpenseRequestDto;
+import com.easyreach.backend.entity.DailyExpense;
+import com.easyreach.backend.mapper.DailyExpenseMapper;
+import com.easyreach.backend.repository.DailyExpenseRepository;
+import com.easyreach.backend.service.impl.DailyExpenseServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DailyExpenseServiceImplTest {
+
+    @Mock
+    private DailyExpenseRepository repository;
+    @Mock
+    private DailyExpenseMapper mapper;
+
+    private DailyExpenseServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DailyExpenseServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        DailyExpenseRequestDto d1 = new DailyExpenseRequestDto();
+        d1.setExpenseId("e1");
+        DailyExpenseRequestDto d1dup = new DailyExpenseRequestDto();
+        d1dup.setExpenseId("e1");
+        DailyExpenseRequestDto d2 = new DailyExpenseRequestDto();
+        d2.setExpenseId("e2");
+
+        DailyExpense existing = new DailyExpense();
+        existing.setExpenseId("e1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        DailyExpense newEntity = new DailyExpense();
+        newEntity.setExpenseId("e2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<DailyExpense>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<DailyExpense> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, DailyExpense> map = saved.stream().collect(java.util.stream.Collectors.toMap(DailyExpense::getExpenseId, p -> p));
+
+        DailyExpense savedExisting = map.get("e1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        DailyExpense savedNew = map.get("e2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/DieselUsageServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/DieselUsageServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.diesel_usage.DieselUsageRequestDto;
+import com.easyreach.backend.entity.DieselUsage;
+import com.easyreach.backend.mapper.DieselUsageMapper;
+import com.easyreach.backend.repository.DieselUsageRepository;
+import com.easyreach.backend.service.impl.DieselUsageServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DieselUsageServiceImplTest {
+
+    @Mock
+    private DieselUsageRepository repository;
+    @Mock
+    private DieselUsageMapper mapper;
+
+    private DieselUsageServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DieselUsageServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        DieselUsageRequestDto d1 = new DieselUsageRequestDto();
+        d1.setDieselUsageId("d1");
+        DieselUsageRequestDto d1dup = new DieselUsageRequestDto();
+        d1dup.setDieselUsageId("d1");
+        DieselUsageRequestDto d2 = new DieselUsageRequestDto();
+        d2.setDieselUsageId("d2");
+
+        DieselUsage existing = new DieselUsage();
+        existing.setDieselUsageId("d1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        DieselUsage newEntity = new DieselUsage();
+        newEntity.setDieselUsageId("d2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<DieselUsage>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<DieselUsage> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, DieselUsage> map = saved.stream().collect(java.util.stream.Collectors.toMap(DieselUsage::getDieselUsageId, p -> p));
+
+        DieselUsage savedExisting = map.get("d1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        DieselUsage savedNew = map.get("d2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/EquipmentUsageServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/EquipmentUsageServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.equipment_usage.EquipmentUsageRequestDto;
+import com.easyreach.backend.entity.EquipmentUsage;
+import com.easyreach.backend.mapper.EquipmentUsageMapper;
+import com.easyreach.backend.repository.EquipmentUsageRepository;
+import com.easyreach.backend.service.impl.EquipmentUsageServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EquipmentUsageServiceImplTest {
+
+    @Mock
+    private EquipmentUsageRepository repository;
+    @Mock
+    private EquipmentUsageMapper mapper;
+
+    private EquipmentUsageServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EquipmentUsageServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        EquipmentUsageRequestDto d1 = new EquipmentUsageRequestDto();
+        d1.setEquipmentUsageId("eq1");
+        EquipmentUsageRequestDto d1dup = new EquipmentUsageRequestDto();
+        d1dup.setEquipmentUsageId("eq1");
+        EquipmentUsageRequestDto d2 = new EquipmentUsageRequestDto();
+        d2.setEquipmentUsageId("eq2");
+
+        EquipmentUsage existing = new EquipmentUsage();
+        existing.setEquipmentUsageId("eq1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        EquipmentUsage newEntity = new EquipmentUsage();
+        newEntity.setEquipmentUsageId("eq2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<EquipmentUsage>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<EquipmentUsage> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, EquipmentUsage> map = saved.stream().collect(java.util.stream.Collectors.toMap(EquipmentUsage::getEquipmentUsageId, p -> p));
+
+        EquipmentUsage savedExisting = map.get("eq1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        EquipmentUsage savedNew = map.get("eq2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/ExpenseMasterServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/ExpenseMasterServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.expense_master.ExpenseMasterRequestDto;
+import com.easyreach.backend.entity.ExpenseMaster;
+import com.easyreach.backend.mapper.ExpenseMasterMapper;
+import com.easyreach.backend.repository.ExpenseMasterRepository;
+import com.easyreach.backend.service.impl.ExpenseMasterServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ExpenseMasterServiceImplTest {
+
+    @Mock
+    private ExpenseMasterRepository repository;
+    @Mock
+    private ExpenseMasterMapper mapper;
+
+    private ExpenseMasterServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExpenseMasterServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        ExpenseMasterRequestDto d1 = new ExpenseMasterRequestDto();
+        d1.setId("em1");
+        ExpenseMasterRequestDto d1dup = new ExpenseMasterRequestDto();
+        d1dup.setId("em1");
+        ExpenseMasterRequestDto d2 = new ExpenseMasterRequestDto();
+        d2.setId("em2");
+
+        ExpenseMaster existing = new ExpenseMaster();
+        existing.setId("em1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        ExpenseMaster newEntity = new ExpenseMaster();
+        newEntity.setId("em2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<ExpenseMaster>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<ExpenseMaster> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, ExpenseMaster> map = saved.stream().collect(java.util.stream.Collectors.toMap(ExpenseMaster::getId, p -> p));
+
+        ExpenseMaster savedExisting = map.get("em1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        ExpenseMaster savedNew = map.get("em2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/InternalVehicleServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/InternalVehicleServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.internal_vehicles.InternalVehicleRequestDto;
+import com.easyreach.backend.entity.InternalVehicle;
+import com.easyreach.backend.mapper.InternalVehicleMapper;
+import com.easyreach.backend.repository.InternalVehicleRepository;
+import com.easyreach.backend.service.impl.InternalVehicleServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InternalVehicleServiceImplTest {
+
+    @Mock
+    private InternalVehicleRepository repository;
+    @Mock
+    private InternalVehicleMapper mapper;
+
+    private InternalVehicleServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InternalVehicleServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        InternalVehicleRequestDto d1 = new InternalVehicleRequestDto();
+        d1.setVehicleId("iv1");
+        InternalVehicleRequestDto d1dup = new InternalVehicleRequestDto();
+        d1dup.setVehicleId("iv1");
+        InternalVehicleRequestDto d2 = new InternalVehicleRequestDto();
+        d2.setVehicleId("iv2");
+
+        InternalVehicle existing = new InternalVehicle();
+        existing.setVehicleId("iv1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        InternalVehicle newEntity = new InternalVehicle();
+        newEntity.setVehicleId("iv2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<InternalVehicle>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<InternalVehicle> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, InternalVehicle> map = saved.stream().collect(java.util.stream.Collectors.toMap(InternalVehicle::getVehicleId, p -> p));
+
+        InternalVehicle savedExisting = map.get("iv1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        InternalVehicle savedNew = map.get("iv2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/PayerServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/PayerServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.payers.PayerRequestDto;
+import com.easyreach.backend.entity.Payer;
+import com.easyreach.backend.mapper.PayerMapper;
+import com.easyreach.backend.repository.PayerRepository;
+import com.easyreach.backend.service.impl.PayerServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PayerServiceImplTest {
+
+    @Mock
+    private PayerRepository repository;
+    @Mock
+    private PayerMapper mapper;
+
+    private PayerServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PayerServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        PayerRequestDto d1 = new PayerRequestDto();
+        d1.setPayerId("p1");
+        PayerRequestDto d1dup = new PayerRequestDto();
+        d1dup.setPayerId("p1");
+        PayerRequestDto d2 = new PayerRequestDto();
+        d2.setPayerId("p2");
+
+        Payer existing = new Payer();
+        existing.setPayerId("p1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        Payer newEntity = new Payer();
+        newEntity.setPayerId("p2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<Payer>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<Payer> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, Payer> map = saved.stream().collect(java.util.stream.Collectors.toMap(Payer::getPayerId, p -> p));
+
+        Payer savedExisting = map.get("p1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        Payer savedNew = map.get("p2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/PayerSettlementServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/PayerSettlementServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.payer_settlements.PayerSettlementRequestDto;
+import com.easyreach.backend.entity.PayerSettlement;
+import com.easyreach.backend.mapper.PayerSettlementMapper;
+import com.easyreach.backend.repository.PayerSettlementRepository;
+import com.easyreach.backend.service.impl.PayerSettlementServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PayerSettlementServiceImplTest {
+
+    @Mock
+    private PayerSettlementRepository repository;
+    @Mock
+    private PayerSettlementMapper mapper;
+
+    private PayerSettlementServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PayerSettlementServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        PayerSettlementRequestDto d1 = new PayerSettlementRequestDto();
+        d1.setSettlementId("s1");
+        PayerSettlementRequestDto d1dup = new PayerSettlementRequestDto();
+        d1dup.setSettlementId("s1");
+        PayerSettlementRequestDto d2 = new PayerSettlementRequestDto();
+        d2.setSettlementId("s2");
+
+        PayerSettlement existing = new PayerSettlement();
+        existing.setSettlementId("s1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        PayerSettlement newEntity = new PayerSettlement();
+        newEntity.setSettlementId("s2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<PayerSettlement>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<PayerSettlement> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, PayerSettlement> map = saved.stream().collect(java.util.stream.Collectors.toMap(PayerSettlement::getSettlementId, p -> p));
+
+        PayerSettlement savedExisting = map.get("s1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        PayerSettlement savedNew = map.get("s2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/VehicleEntryServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/VehicleEntryServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.vehicle_entries.VehicleEntryRequestDto;
+import com.easyreach.backend.entity.VehicleEntry;
+import com.easyreach.backend.mapper.VehicleEntryMapper;
+import com.easyreach.backend.repository.VehicleEntryRepository;
+import com.easyreach.backend.service.impl.VehicleEntryServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VehicleEntryServiceImplTest {
+
+    @Mock
+    private VehicleEntryRepository repository;
+    @Mock
+    private VehicleEntryMapper mapper;
+
+    private VehicleEntryServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VehicleEntryServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        VehicleEntryRequestDto d1 = new VehicleEntryRequestDto();
+        d1.setEntryId("v1");
+        VehicleEntryRequestDto d1dup = new VehicleEntryRequestDto();
+        d1dup.setEntryId("v1");
+        VehicleEntryRequestDto d2 = new VehicleEntryRequestDto();
+        d2.setEntryId("v2");
+
+        VehicleEntry existing = new VehicleEntry();
+        existing.setEntryId("v1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        VehicleEntry newEntity = new VehicleEntry();
+        newEntity.setEntryId("v2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<VehicleEntry>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<VehicleEntry> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, VehicleEntry> map = saved.stream().collect(java.util.stream.Collectors.toMap(VehicleEntry::getEntryId, p -> p));
+
+        VehicleEntry savedExisting = map.get("v1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        VehicleEntry savedNew = map.get("v2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+

--- a/src/test/java/com/easyreach/backend/service/VehicleTypeServiceImplTest.java
+++ b/src/test/java/com/easyreach/backend/service/VehicleTypeServiceImplTest.java
@@ -1,0 +1,85 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.vehicle_types.VehicleTypeRequestDto;
+import com.easyreach.backend.entity.VehicleType;
+import com.easyreach.backend.mapper.VehicleTypeMapper;
+import com.easyreach.backend.repository.VehicleTypeRepository;
+import com.easyreach.backend.service.impl.VehicleTypeServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VehicleTypeServiceImplTest {
+
+    @Mock
+    private VehicleTypeRepository repository;
+    @Mock
+    private VehicleTypeMapper mapper;
+
+    private VehicleTypeServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new VehicleTypeServiceImpl(repository, mapper);
+    }
+
+    @Test
+    void bulkSync_deduplicates_merges_and_sets_timestamps() {
+        VehicleTypeRequestDto d1 = new VehicleTypeRequestDto();
+        d1.setId("t1");
+        VehicleTypeRequestDto d1dup = new VehicleTypeRequestDto();
+        d1dup.setId("t1");
+        VehicleTypeRequestDto d2 = new VehicleTypeRequestDto();
+        d2.setId("t2");
+
+        VehicleType existing = new VehicleType();
+        existing.setId("t1");
+        OffsetDateTime old = OffsetDateTime.now().minusDays(1);
+        existing.setCreatedAt(old);
+        existing.setUpdatedAt(old);
+
+        when(repository.findAllById(any())).thenReturn(List.of(existing));
+
+        VehicleType newEntity = new VehicleType();
+        newEntity.setId("t2");
+        when(mapper.toEntity(d2)).thenReturn(newEntity);
+
+        ArgumentCaptor<List<VehicleType>> saveCaptor = ArgumentCaptor.forClass(List.class);
+
+        int count = service.bulkSync(Arrays.asList(d1, d1dup, d2));
+
+        assertEquals(2, count);
+        verify(mapper).merge(d1dup, existing);
+        verify(mapper).toEntity(d2);
+
+        verify(repository).saveAll(saveCaptor.capture());
+        List<VehicleType> saved = saveCaptor.getValue();
+        assertEquals(2, saved.size());
+
+        Map<String, VehicleType> map = saved.stream().collect(java.util.stream.Collectors.toMap(VehicleType::getId, p -> p));
+
+        VehicleType savedExisting = map.get("t1");
+        assertNotNull(savedExisting);
+        assertEquals(old, savedExisting.getCreatedAt());
+        assertTrue(savedExisting.getUpdatedAt().isAfter(old));
+        assertTrue(savedExisting.getIsSynced());
+
+        VehicleType savedNew = map.get("t2");
+        assertNotNull(savedNew);
+        assertEquals(savedNew.getCreatedAt(), savedNew.getUpdatedAt());
+        assertTrue(savedNew.getIsSynced());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Deduplicate DTOs in bulk sync operations across services and merge updates with existing entities
- Add merge methods to mappers and manage timestamps and sync flags
- Introduce unit tests verifying deduplication, merging, and timestamp handling for all services

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for com.easyreach:easyreach-backend:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_68b3e7595a84832d8e19a6e472690d40