### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/src/test/java/com/easyreach/backend/EasyreachBackendApplicationTest.java
+++ b/src/test/java/com/easyreach/backend/EasyreachBackendApplicationTest.java
@@ -1,0 +1,13 @@
+package com.easyreach.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EasyreachBackendApplicationTest {
+
+    @Test
+    void contextLoads() {
+        // verifies that the Spring application context loads successfully
+    }
+}

--- a/src/test/java/com/easyreach/backend/OpenApiConfigTest.java
+++ b/src/test/java/com/easyreach/backend/OpenApiConfigTest.java
@@ -1,0 +1,21 @@
+package com.easyreach.backend;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class OpenApiConfigTest {
+
+    @Autowired
+    private OpenAPI openAPI;
+
+    @Test
+    void openApiBeanConfigured() {
+        assertThat(openAPI).isNotNull();
+        assertThat(openAPI.getInfo().getTitle()).isEqualTo("Easyreach API");
+    }
+}

--- a/src/test/java/com/easyreach/backend/auth/dto/AuthResponseTest.java
+++ b/src/test/java/com/easyreach/backend/auth/dto/AuthResponseTest.java
@@ -1,0 +1,16 @@
+package com.easyreach.backend.auth.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthResponseTest {
+
+    @Test
+    void gettersAndSetters() {
+        AuthResponse response = new AuthResponse("access", "refresh");
+
+        assertThat(response.getAccessToken()).isEqualTo("access");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh");
+    }
+}

--- a/src/test/java/com/easyreach/backend/auth/dto/LoginRequestTest.java
+++ b/src/test/java/com/easyreach/backend/auth/dto/LoginRequestTest.java
@@ -1,0 +1,28 @@
+package com.easyreach.backend.auth.dto;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoginRequestTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void validationFailsForBlankFields() {
+        LoginRequest req = new LoginRequest();
+        assertThat(validator.validate(req)).hasSizeGreaterThan(0);
+    }
+
+    @Test
+    void gettersAndSetters() {
+        LoginRequest req = new LoginRequest();
+        req.setEmail("user@example.com");
+        req.setPassword("pass");
+        assertThat(req.getEmail()).isEqualTo("user@example.com");
+        assertThat(req.getPassword()).isEqualTo("pass");
+        assertThat(validator.validate(req)).isEmpty();
+    }
+}

--- a/src/test/java/com/easyreach/backend/auth/entity/RefreshTokenTest.java
+++ b/src/test/java/com/easyreach/backend/auth/entity/RefreshTokenTest.java
@@ -1,0 +1,26 @@
+package com.easyreach.backend.auth.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RefreshTokenTest {
+
+    @Test
+    void builderAndGetters() {
+        OffsetDateTime now = OffsetDateTime.now();
+        RefreshToken token = RefreshToken.builder()
+                .jti("id")
+                .userId("user")
+                .issuedAt(now)
+                .expiresAt(now.plusHours(1))
+                .isSynced(true)
+                .build();
+
+        assertThat(token.getJti()).isEqualTo("id");
+        assertThat(token.getExpiresAt()).isAfter(token.getIssuedAt());
+        assertThat(token.getIsSynced()).isTrue();
+    }
+}

--- a/src/test/java/com/easyreach/backend/auth/entity/UserAdapterTest.java
+++ b/src/test/java/com/easyreach/backend/auth/entity/UserAdapterTest.java
@@ -1,0 +1,33 @@
+package com.easyreach.backend.auth.entity;
+
+import com.easyreach.backend.entity.User;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserAdapterTest {
+
+    @Test
+    void wrapsUserDetailsCorrectly() {
+        OffsetDateTime now = OffsetDateTime.now();
+        User domainUser = User.builder()
+                .id("1")
+                .employeeId("E1")
+                .email("user@example.com")
+                .password("pass")
+                .role("ADMIN")
+                .isActive(true)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        UserAdapter adapter = new UserAdapter(domainUser);
+
+        assertThat(adapter.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_ADMIN");
+        assertThat(adapter.getUsername()).isEqualTo("user@example.com");
+        assertThat(adapter.isEnabled()).isTrue();
+        assertThat(adapter.getDomainUser()).isSameAs(domainUser);
+    }
+}

--- a/src/test/java/com/easyreach/backend/controller/DailyExpenseControllerTest.java
+++ b/src/test/java/com/easyreach/backend/controller/DailyExpenseControllerTest.java
@@ -1,0 +1,36 @@
+package com.easyreach.backend.controller;
+
+import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.daily_expenses.DailyExpenseResponseDto;
+import com.easyreach.backend.service.DailyExpenseService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DailyExpenseController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DailyExpenseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DailyExpenseService service;
+
+    @Test
+    void getDailyExpense() throws Exception {
+        Mockito.when(service.get("1")).thenReturn(ApiResponse.success(new DailyExpenseResponseDto()));
+
+        mockMvc.perform(get("/api/daily-expenses/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+}

--- a/src/test/java/com/easyreach/backend/controller/PayerControllerTest.java
+++ b/src/test/java/com/easyreach/backend/controller/PayerControllerTest.java
@@ -1,0 +1,36 @@
+package com.easyreach.backend.controller;
+
+import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.payers.PayerResponseDto;
+import com.easyreach.backend.service.PayerService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PayerController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PayerControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PayerService service;
+
+    @Test
+    void getPayer() throws Exception {
+        Mockito.when(service.get("1")).thenReturn(ApiResponse.success(new PayerResponseDto()));
+
+        mockMvc.perform(get("/api/payers/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+}

--- a/src/test/java/com/easyreach/backend/controller/VehicleEntryControllerTest.java
+++ b/src/test/java/com/easyreach/backend/controller/VehicleEntryControllerTest.java
@@ -1,0 +1,36 @@
+package com.easyreach.backend.controller;
+
+import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.vehicle_entries.VehicleEntryResponseDto;
+import com.easyreach.backend.service.VehicleEntryService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VehicleEntryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class VehicleEntryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private VehicleEntryService service;
+
+    @Test
+    void getVehicleEntry() throws Exception {
+        Mockito.when(service.get("1")).thenReturn(ApiResponse.success(new VehicleEntryResponseDto()));
+
+        mockMvc.perform(get("/api/vehicle-entries/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+}

--- a/src/test/java/com/easyreach/backend/dto/CompanyRequestDtoTest.java
+++ b/src/test/java/com/easyreach/backend/dto/CompanyRequestDtoTest.java
@@ -1,0 +1,26 @@
+package com.easyreach.backend.dto;
+
+import com.easyreach.backend.dto.companies.CompanyRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CompanyRequestDtoTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void serializeAndDeserialize() throws Exception {
+        CompanyRequestDto dto = new CompanyRequestDto(
+                "u1","c1","name","123","coord","loc", LocalDate.now(),"owner","999","owner@ex.com",
+                LocalDate.now(), true, true, "creator", OffsetDateTime.now(), "upd", OffsetDateTime.now());
+
+        String json = mapper.writeValueAsString(dto);
+        CompanyRequestDto read = mapper.readValue(json, CompanyRequestDto.class);
+        assertThat(read.getCompanyName()).isEqualTo(dto.getCompanyName());
+    }
+}

--- a/src/test/java/com/easyreach/backend/entity/CompanyEntityTest.java
+++ b/src/test/java/com/easyreach/backend/entity/CompanyEntityTest.java
@@ -1,0 +1,34 @@
+package com.easyreach.backend.entity;
+
+import jakarta.persistence.Entity;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CompanyEntityTest {
+
+    @Test
+    void entityAnnotationAndBuilder() {
+        assertThat(Company.class.isAnnotationPresent(Entity.class)).isTrue();
+        Company company = Company.builder()
+                .uuid("c1")
+                .companyCode("code")
+                .companyName("Name")
+                .companyContactNo("123")
+                .companyLocation("loc")
+                .companyRegistrationDate(LocalDate.now())
+                .ownerName("Owner")
+                .ownerMobileNo("999")
+                .ownerEmailAddress("owner@example.com")
+                .ownerDob(LocalDate.now())
+                .isActive(true)
+                .isSynced(true)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+        assertThat(company.getCompanyName()).isEqualTo("Name");
+    }
+}

--- a/src/test/java/com/easyreach/backend/entity/EquipmentUsageEntityTest.java
+++ b/src/test/java/com/easyreach/backend/entity/EquipmentUsageEntityTest.java
@@ -1,0 +1,33 @@
+package com.easyreach.backend.entity;
+
+import jakarta.persistence.Entity;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EquipmentUsageEntityTest {
+
+    @Test
+    void entityAnnotationAndBuilder() {
+        assertThat(EquipmentUsage.class.isAnnotationPresent(Entity.class)).isTrue();
+        OffsetDateTime now = OffsetDateTime.now();
+        EquipmentUsage usage = EquipmentUsage.builder()
+                .equipmentUsageId("u1")
+                .equipmentName("Excavator")
+                .equipmentType("Heavy")
+                .startKm(BigDecimal.ONE)
+                .endKm(BigDecimal.TEN)
+                .startTime(now)
+                .endTime(now.plusHours(1))
+                .date(now)
+                .companyUuid("c1")
+                .isSynced(true)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        assertThat(usage.getEquipmentName()).isEqualTo("Excavator");
+    }
+}

--- a/src/test/java/com/easyreach/backend/entity/VehicleEntryEntityTest.java
+++ b/src/test/java/com/easyreach/backend/entity/VehicleEntryEntityTest.java
@@ -1,0 +1,43 @@
+package com.easyreach.backend.entity;
+
+import jakarta.persistence.Entity;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VehicleEntryEntityTest {
+
+    @Test
+    void entityAnnotationAndBuilder() {
+        assertThat(VehicleEntry.class.isAnnotationPresent(Entity.class)).isTrue();
+        OffsetDateTime now = OffsetDateTime.now();
+        VehicleEntry entry = VehicleEntry.builder()
+                .entryId("e1")
+                .companyUuid("c1")
+                .payerId("p1")
+                .vehicleNumber("ABC123")
+                .vehicleType("Truck")
+                .fromAddress("from")
+                .toAddress("to")
+                .driverName("Driver")
+                .driverContactNo("999")
+                .commission(BigDecimal.ONE)
+                .beta(BigDecimal.ONE)
+                .amount(BigDecimal.TEN)
+                .paytype("CASH")
+                .entryDate(LocalDate.now())
+                .entryTime(now)
+                .paidAmount(BigDecimal.ONE)
+                .pendingAmt(BigDecimal.ZERO)
+                .isSettled(false)
+                .isSynced(true)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        assertThat(entry.getVehicleNumber()).isEqualTo("ABC123");
+    }
+}

--- a/src/test/java/com/easyreach/backend/mapper/PayerMapperTest.java
+++ b/src/test/java/com/easyreach/backend/mapper/PayerMapperTest.java
@@ -1,0 +1,29 @@
+package com.easyreach.backend.mapper;
+
+import com.easyreach.backend.dto.payers.PayerRequestDto;
+import com.easyreach.backend.dto.payers.PayerResponseDto;
+import com.easyreach.backend.entity.Payer;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PayerMapperTest {
+    private final PayerMapper mapper = Mappers.getMapper(PayerMapper.class);
+
+    @Test
+    void toEntityAndToDto() {
+        OffsetDateTime now = OffsetDateTime.now();
+        PayerRequestDto req = new PayerRequestDto(
+                "p1","name","123","addr", LocalDate.now(),100,"c1",true,
+                "creator", now, "upd", now, null);
+
+        Payer entity = mapper.toEntity(req);
+        PayerResponseDto dto = mapper.toDto(entity);
+
+        assertThat(dto.getPayerName()).isEqualTo(req.getPayerName());
+    }
+}

--- a/src/test/java/com/easyreach/backend/mapper/VehicleEntryMapperTest.java
+++ b/src/test/java/com/easyreach/backend/mapper/VehicleEntryMapperTest.java
@@ -1,0 +1,32 @@
+package com.easyreach.backend.mapper;
+
+import com.easyreach.backend.dto.vehicle_entries.VehicleEntryRequestDto;
+import com.easyreach.backend.dto.vehicle_entries.VehicleEntryResponseDto;
+import com.easyreach.backend.entity.VehicleEntry;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VehicleEntryMapperTest {
+    private final VehicleEntryMapper mapper = Mappers.getMapper(VehicleEntryMapper.class);
+
+    @Test
+    void toEntityAndToDto() {
+        OffsetDateTime now = OffsetDateTime.now();
+        VehicleEntryRequestDto req = new VehicleEntryRequestDto(
+                "e1","c1","p1","ABC123","Truck","from","to","driver","999",
+                BigDecimal.ONE, BigDecimal.ONE, "ref", BigDecimal.TEN, "CASH", LocalDate.now(), now,
+                null, null, null, BigDecimal.ONE, BigDecimal.ZERO, false, null, null, true,
+                "creator", now, "upd", now);
+
+        VehicleEntry entity = mapper.toEntity(req);
+        VehicleEntryResponseDto dto = mapper.toDto(entity);
+
+        assertThat(dto.getVehicleNumber()).isEqualTo(req.getVehicleNumber());
+    }
+}

--- a/src/test/java/com/easyreach/backend/repository/CompanyRepositoryTest.java
+++ b/src/test/java/com/easyreach/backend/repository/CompanyRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.easyreach.backend.repository;
+
+import com.easyreach.backend.entity.Company;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class CompanyRepositoryTest {
+
+    @Autowired
+    private CompanyRepository repository;
+
+    @Test
+    void saveAndFind() {
+        Company company = Company.builder()
+                .uuid("c1")
+                .companyCode("code")
+                .companyName("Name")
+                .companyContactNo("123")
+                .companyCoordinates("coords")
+                .companyLocation("Loc")
+                .companyRegistrationDate(LocalDate.now())
+                .ownerName("Owner")
+                .ownerMobileNo("999")
+                .ownerEmailAddress("owner@example.com")
+                .ownerDob(LocalDate.now())
+                .isActive(true)
+                .isSynced(true)
+                .createdAt(OffsetDateTime.now())
+                .updatedAt(OffsetDateTime.now())
+                .build();
+
+        repository.save(company);
+        assertThat(repository.findById("c1")).contains(company);
+    }
+}

--- a/src/test/java/com/easyreach/backend/repository/VehicleEntryRepositoryTest.java
+++ b/src/test/java/com/easyreach/backend/repository/VehicleEntryRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.easyreach.backend.repository;
+
+import com.easyreach.backend.entity.VehicleEntry;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class VehicleEntryRepositoryTest {
+
+    @Autowired
+    private VehicleEntryRepository repository;
+
+    @Test
+    void saveAndFind() {
+        OffsetDateTime now = OffsetDateTime.now();
+        VehicleEntry entry = VehicleEntry.builder()
+                .entryId("e1")
+                .companyUuid("c1")
+                .payerId("p1")
+                .vehicleNumber("ABC123")
+                .vehicleType("Truck")
+                .fromAddress("from")
+                .toAddress("to")
+                .driverName("Driver")
+                .driverContactNo("999")
+                .commission(BigDecimal.ONE)
+                .beta(BigDecimal.ONE)
+                .amount(BigDecimal.TEN)
+                .paytype("CASH")
+                .entryDate(LocalDate.now())
+                .entryTime(now)
+                .paidAmount(BigDecimal.ONE)
+                .pendingAmt(BigDecimal.ZERO)
+                .isSettled(false)
+                .isSynced(true)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        repository.save(entry);
+        assertThat(repository.findById("e1")).contains(entry);
+    }
+}

--- a/src/test/java/com/easyreach/backend/service/UserServiceTest.java
+++ b/src/test/java/com/easyreach/backend/service/UserServiceTest.java
@@ -1,0 +1,19 @@
+package com.easyreach.backend.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void userServiceBeanLoads() {
+        assertThat(userService).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- verify application context and OpenAPI configuration load
- add unit tests for auth entities, DTOs, and controllers
- test mapper conversions and repository persistence
- cover entity builders, DTO serialization, and service bean loading

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f13ecf18832dab6d608b9750f0a0