### PR TITLE
Ensure repository tests use in-memory H2

### DIFF
--- a/src/test/java/com/easyreach/backend/repository/CompanyRepositoryTest.java
+++ b/src/test/java/com/easyreach/backend/repository/CompanyRepositoryTest.java
@@ -4,6 +4,7 @@ import com.easyreach.backend.entity.Company;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -11,6 +12,10 @@ import java.time.OffsetDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
+})
 class CompanyRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/easyreach/backend/repository/VehicleEntryRepositoryTest.java
+++ b/src/test/java/com/easyreach/backend/repository/VehicleEntryRepositoryTest.java
@@ -4,6 +4,7 @@ import com.easyreach.backend.entity.VehicleEntry;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -12,6 +13,10 @@ import java.time.OffsetDateTime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@TestPropertySource(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.flyway.enabled=false"
+})
 class VehicleEntryRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- configure CompanyRepositoryTest and VehicleEntryRepositoryTest to create/drop schema and bypass Flyway
- rely on embedded H2 during JPA tests

## Testing
- `mvn -q -Dtest=CompanyRepositoryTest,VehicleEntryRepositoryTest test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f447aae0832da5a4ed504768085d