### PR TITLE
Add soft-delete metadata to entities

### DIFF
--- a/src/main/java/com/easyreach/backend/dto/CompanyDto.java
+++ b/src/main/java/com/easyreach/backend/dto/CompanyDto.java
@@ -29,4 +29,8 @@ public class CompanyDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/DailyExpenseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/DailyExpenseDto.java
@@ -23,4 +23,8 @@ public class DailyExpenseDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/DieselUsageDto.java
+++ b/src/main/java/com/easyreach/backend/dto/DieselUsageDto.java
@@ -22,4 +22,8 @@ public class DieselUsageDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/EquipmentUsageDto.java
+++ b/src/main/java/com/easyreach/backend/dto/EquipmentUsageDto.java
@@ -26,4 +26,8 @@ public class EquipmentUsageDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/ExpenseMasterDto.java
+++ b/src/main/java/com/easyreach/backend/dto/ExpenseMasterDto.java
@@ -20,4 +20,8 @@ public class ExpenseMasterDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/InternalVehicleDto.java
+++ b/src/main/java/com/easyreach/backend/dto/InternalVehicleDto.java
@@ -22,4 +22,8 @@ public class InternalVehicleDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/PayerDto.java
+++ b/src/main/java/com/easyreach/backend/dto/PayerDto.java
@@ -25,4 +25,8 @@ public class PayerDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/PayerSettlementDto.java
+++ b/src/main/java/com/easyreach/backend/dto/PayerSettlementDto.java
@@ -22,4 +22,8 @@ public class PayerSettlementDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/VehicleEntryDto.java
+++ b/src/main/java/com/easyreach/backend/dto/VehicleEntryDto.java
@@ -42,4 +42,8 @@ public class VehicleEntryDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/VehicleTypeDto.java
+++ b/src/main/java/com/easyreach/backend/dto/VehicleTypeDto.java
@@ -21,4 +21,8 @@ public class VehicleTypeDto {
   private Instant createdAt;
   private String updatedBy;
   private Instant updatedAt;
+
+  private Boolean deleted;
+  private Instant deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/companies/CompanyRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/companies/CompanyRequestDto.java
@@ -43,4 +43,11 @@ public class CompanyRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/companies/CompanyResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/companies/CompanyResponseDto.java
@@ -25,4 +25,8 @@ public class CompanyResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/daily_expenses/DailyExpenseRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/daily_expenses/DailyExpenseRequestDto.java
@@ -41,4 +41,11 @@ public class DailyExpenseRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/daily_expenses/DailyExpenseResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/daily_expenses/DailyExpenseResponseDto.java
@@ -24,4 +24,8 @@ public class DailyExpenseResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/diesel_usage/DieselUsageRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/diesel_usage/DieselUsageRequestDto.java
@@ -29,4 +29,11 @@ public class DieselUsageRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/diesel_usage/DieselUsageResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/diesel_usage/DieselUsageResponseDto.java
@@ -18,4 +18,8 @@ public class DieselUsageResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/equipment_usage/EquipmentUsageRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/equipment_usage/EquipmentUsageRequestDto.java
@@ -37,4 +37,11 @@ public class EquipmentUsageRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/equipment_usage/EquipmentUsageResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/equipment_usage/EquipmentUsageResponseDto.java
@@ -22,4 +22,8 @@ public class EquipmentUsageResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/expense_master/ExpenseMasterRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/expense_master/ExpenseMasterRequestDto.java
@@ -25,4 +25,11 @@ public class ExpenseMasterRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/expense_master/ExpenseMasterResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/expense_master/ExpenseMasterResponseDto.java
@@ -16,4 +16,8 @@ public class ExpenseMasterResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/internal_vehicles/InternalVehicleRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/internal_vehicles/InternalVehicleRequestDto.java
@@ -29,4 +29,11 @@ public class InternalVehicleRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/internal_vehicles/InternalVehicleResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/internal_vehicles/InternalVehicleResponseDto.java
@@ -18,4 +18,8 @@ public class InternalVehicleResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/payer_settlements/PayerSettlementRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/payer_settlements/PayerSettlementRequestDto.java
@@ -29,4 +29,11 @@ public class PayerSettlementRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/payer_settlements/PayerSettlementResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/payer_settlements/PayerSettlementResponseDto.java
@@ -18,4 +18,8 @@ public class PayerSettlementResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/payers/PayerRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/payers/PayerRequestDto.java
@@ -34,5 +34,10 @@ public class PayerRequestDto {
   @NotNull
   private OffsetDateTime updatedAt;
 
+  @NotNull
+  private Boolean deleted;
+
   private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/payers/PayerResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/payers/PayerResponseDto.java
@@ -20,5 +20,7 @@ public class PayerResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+  private Boolean deleted;
   private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/users/UserRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/users/UserRequestDto.java
@@ -41,4 +41,11 @@ public class UserRequestDto {
   private OffsetDateTime createdAt;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/users/UserResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/users/UserResponseDto.java
@@ -24,4 +24,8 @@ public class UserResponseDto {
   private Boolean isActive;
   private OffsetDateTime createdAt;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/vehicle_entries/VehicleEntryRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/vehicle_entries/VehicleEntryRequestDto.java
@@ -67,4 +67,11 @@ public class VehicleEntryRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/vehicle_entries/VehicleEntryResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/vehicle_entries/VehicleEntryResponseDto.java
@@ -37,4 +37,8 @@ public class VehicleEntryResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/vehicle_types/VehicleTypeRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/vehicle_types/VehicleTypeRequestDto.java
@@ -27,4 +27,11 @@ public class VehicleTypeRequestDto {
   private String updatedBy;
   @NotNull
   private OffsetDateTime updatedAt;
+
+  @NotNull
+  private Boolean deleted;
+
+  private OffsetDateTime deletedAt;
+
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/dto/vehicle_types/VehicleTypeResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/vehicle_types/VehicleTypeResponseDto.java
@@ -17,4 +17,8 @@ public class VehicleTypeResponseDto {
   private OffsetDateTime createdAt;
   private String updatedBy;
   private OffsetDateTime updatedAt;
+
+  private Boolean deleted;
+  private OffsetDateTime deletedAt;
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/Company.java
+++ b/src/main/java/com/easyreach/backend/entity/Company.java
@@ -47,4 +47,14 @@ public class Company {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/DailyExpense.java
+++ b/src/main/java/com/easyreach/backend/entity/DailyExpense.java
@@ -45,4 +45,14 @@ public class DailyExpense {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/DieselUsage.java
+++ b/src/main/java/com/easyreach/backend/entity/DieselUsage.java
@@ -33,4 +33,14 @@ public class DieselUsage {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/EquipmentUsage.java
+++ b/src/main/java/com/easyreach/backend/entity/EquipmentUsage.java
@@ -41,4 +41,14 @@ public class EquipmentUsage {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/ExpenseMaster.java
+++ b/src/main/java/com/easyreach/backend/entity/ExpenseMaster.java
@@ -29,4 +29,14 @@ public class ExpenseMaster {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/InternalVehicle.java
+++ b/src/main/java/com/easyreach/backend/entity/InternalVehicle.java
@@ -33,4 +33,14 @@ public class InternalVehicle {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/Payer.java
+++ b/src/main/java/com/easyreach/backend/entity/Payer.java
@@ -37,6 +37,14 @@ public class Payer {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
   @Column(name = "deleted_at")
   private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/PayerSettlement.java
+++ b/src/main/java/com/easyreach/backend/entity/PayerSettlement.java
@@ -33,4 +33,14 @@ public class PayerSettlement {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/User.java
+++ b/src/main/java/com/easyreach/backend/entity/User.java
@@ -54,6 +54,16 @@ public class User implements UserDetails {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
+    @Column(name = "deleted", nullable = false)
+    private boolean deleted;
+
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "change_id")
+    private Long changeId;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_" + role));

--- a/src/main/java/com/easyreach/backend/entity/VehicleEntry.java
+++ b/src/main/java/com/easyreach/backend/entity/VehicleEntry.java
@@ -71,4 +71,14 @@ public class VehicleEntry {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/VehicleType.java
+++ b/src/main/java/com/easyreach/backend/entity/VehicleType.java
@@ -31,4 +31,14 @@ public class VehicleType {
   private String updatedBy;
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
+
+  @Column(name = "deleted", nullable = false)
+  private boolean deleted;
+
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
+
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "change_id")
+  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/mapper/CompanyMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/CompanyMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.companies.CompanyResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface CompanyMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     Company toEntity(CompanyRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     CompanyResponseDto toDto(Company entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/DailyExpenseMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/DailyExpenseMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.daily_expenses.DailyExpenseResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface DailyExpenseMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     DailyExpense toEntity(DailyExpenseRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     DailyExpenseResponseDto toDto(DailyExpense entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/DieselUsageMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/DieselUsageMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.diesel_usage.DieselUsageResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface DieselUsageMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     DieselUsage toEntity(DieselUsageRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     DieselUsageResponseDto toDto(DieselUsage entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/EquipmentUsageMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/EquipmentUsageMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.equipment_usage.EquipmentUsageResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface EquipmentUsageMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     EquipmentUsage toEntity(EquipmentUsageRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     EquipmentUsageResponseDto toDto(EquipmentUsage entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/ExpenseMasterMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/ExpenseMasterMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.expense_master.ExpenseMasterResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface ExpenseMasterMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     ExpenseMaster toEntity(ExpenseMasterRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     ExpenseMasterResponseDto toDto(ExpenseMaster entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/InternalVehicleMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/InternalVehicleMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.internal_vehicles.InternalVehicleResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface InternalVehicleMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     InternalVehicle toEntity(InternalVehicleRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     InternalVehicleResponseDto toDto(InternalVehicle entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/PayerMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/PayerMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.payers.PayerResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface PayerMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     Payer toEntity(PayerRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     PayerResponseDto toDto(Payer entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/PayerSettlementMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/PayerSettlementMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.payer_settlements.PayerSettlementResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface PayerSettlementMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     PayerSettlement toEntity(PayerSettlementRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     PayerSettlementResponseDto toDto(PayerSettlement entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/UserMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/UserMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.users.UserResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     User toEntity(UserRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     UserResponseDto toDto(User entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/VehicleEntryMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/VehicleEntryMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.vehicle_entries.VehicleEntryResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface VehicleEntryMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     VehicleEntry toEntity(VehicleEntryRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     VehicleEntryResponseDto toDto(VehicleEntry entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/java/com/easyreach/backend/mapper/VehicleTypeMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/VehicleTypeMapper.java
@@ -7,7 +7,14 @@ import com.easyreach.backend.dto.vehicle_types.VehicleTypeResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface VehicleTypeMapper {
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     VehicleType toEntity(VehicleTypeRequestDto dto);
+
+    @Mapping(target = "deleted", source = "deleted")
+    @Mapping(target = "deletedAt", source = "deletedAt")
+    @Mapping(target = "changeId", source = "changeId")
     VehicleTypeResponseDto toDto(VehicleType entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)

--- a/src/main/resources/db/migration/V2__sync_columns.sql
+++ b/src/main/resources/db/migration/V2__sync_columns.sql
@@ -1,0 +1,90 @@
+-- Add sync columns to existing tables
+
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE internal_vehicles
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE vehicle_entries
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE payer_settlements
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE payers
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE expense_master
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE daily_expenses
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE diesel_usage
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE equipment_usage
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+ALTER TABLE vehicle_types
+    ADD COLUMN IF NOT EXISTS deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS change_id BIGSERIAL;
+
+-- Indexes to support synchronization queries
+CREATE INDEX IF NOT EXISTS idx_companies_uuid_updated_at ON companies(uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_companies_uuid_deleted_deleted_at ON companies(uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_users_company_uuid_updated_at ON users(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_users_company_uuid_deleted_deleted_at ON users(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_internal_vehicles_company_uuid_updated_at ON internal_vehicles(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_internal_vehicles_company_uuid_deleted_deleted_at ON internal_vehicles(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_entries_company_uuid_updated_at ON vehicle_entries(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_vehicle_entries_company_uuid_deleted_deleted_at ON vehicle_entries(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_payer_settlements_company_uuid_updated_at ON payer_settlements(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_payer_settlements_company_uuid_deleted_deleted_at ON payer_settlements(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_payers_company_uuid_updated_at ON payers(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_payers_company_uuid_deleted_deleted_at ON payers(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_expense_master_company_uuid_updated_at ON expense_master(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_expense_master_company_uuid_deleted_deleted_at ON expense_master(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_daily_expenses_company_uuid_updated_at ON daily_expenses(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_daily_expenses_company_uuid_deleted_deleted_at ON daily_expenses(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_diesel_usage_company_uuid_updated_at ON diesel_usage(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_diesel_usage_company_uuid_deleted_deleted_at ON diesel_usage(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_equipment_usage_company_uuid_updated_at ON equipment_usage(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_equipment_usage_company_uuid_deleted_deleted_at ON equipment_usage(company_uuid, deleted, deleted_at);
+
+CREATE INDEX IF NOT EXISTS idx_vehicle_types_company_uuid_updated_at ON vehicle_types(company_uuid, updated_at);
+CREATE INDEX IF NOT EXISTS idx_vehicle_types_company_uuid_deleted_deleted_at ON vehicle_types(company_uuid, deleted, deleted_at);


### PR DESCRIPTION
## Summary
- add `deleted`, `deleted_at` and `change_id` fields across core entities and DTOs
- update MapStruct mappers to handle new fields
- add migration adding soft-delete columns and sync indexes

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fb8b881c832d9e9551c26db5fd22