### PR TITLE
Add sync change tracking for repositories and services

### DIFF
--- a/src/main/java/com/easyreach/backend/repository/CompanyRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/CompanyRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.Company;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface CompanyRepository extends JpaRepository<Company, String> {
+    List<Company> findByUuidAndUpdatedAtGreaterThanEqual(String uuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<Company> findByUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String uuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/DailyExpenseRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/DailyExpenseRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.DailyExpense;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface DailyExpenseRepository extends JpaRepository<DailyExpense, String> {
+    List<DailyExpense> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<DailyExpense> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/DieselUsageRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/DieselUsageRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.DieselUsage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface DieselUsageRepository extends JpaRepository<DieselUsage, String> {
+    List<DieselUsage> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<DieselUsage> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/EquipmentUsageRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/EquipmentUsageRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.EquipmentUsage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface EquipmentUsageRepository extends JpaRepository<EquipmentUsage, String> {
+    List<EquipmentUsage> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<EquipmentUsage> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/ExpenseMasterRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/ExpenseMasterRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.ExpenseMaster;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface ExpenseMasterRepository extends JpaRepository<ExpenseMaster, String> {
+    List<ExpenseMaster> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<ExpenseMaster> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/InternalVehicleRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/InternalVehicleRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.InternalVehicle;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface InternalVehicleRepository extends JpaRepository<InternalVehicle, String> {
+    List<InternalVehicle> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<InternalVehicle> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/PayerRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/PayerRepository.java
@@ -5,7 +5,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+
 public interface PayerRepository extends JpaRepository<Payer, String> {
     Page<Payer> findByCompanyUuidAndDeletedAtIsNull(String companyUuid, Pageable pageable);
     Page<Payer> findByCompanyUuidAndPayerNameContainingIgnoreCaseAndDeletedAtIsNull(String companyUuid, String q, Pageable pageable);
+
+    List<Payer> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<Payer> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/PayerSettlementRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/PayerSettlementRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.PayerSettlement;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface PayerSettlementRepository extends JpaRepository<PayerSettlement, String> {
+    List<PayerSettlement> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<PayerSettlement> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/UserRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/UserRepository.java
@@ -1,10 +1,17 @@
 package com.easyreach.backend.repository;
 
 import com.easyreach.backend.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmailIgnoreCase(String email);
+
+    List<User> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<User> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/VehicleEntryRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/VehicleEntryRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.VehicleEntry;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface VehicleEntryRepository extends JpaRepository<VehicleEntry, String> {
+    List<VehicleEntry> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<VehicleEntry> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/repository/VehicleTypeRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/VehicleTypeRepository.java
@@ -1,7 +1,14 @@
 package com.easyreach.backend.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import com.easyreach.backend.entity.VehicleType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public interface VehicleTypeRepository extends JpaRepository<VehicleType, String> {
+    List<VehicleType> findByCompanyUuidAndUpdatedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
+
+    List<VehicleType> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 }

--- a/src/main/java/com/easyreach/backend/service/CompanyService.java
+++ b/src/main/java/com/easyreach/backend/service/CompanyService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface CompanyService {
     ApiResponse<CompanyResponseDto> create(CompanyRequestDto dto);
@@ -15,4 +17,5 @@ public interface CompanyService {
     ApiResponse<CompanyResponseDto> get(String id);
     ApiResponse<Page<CompanyResponseDto>> list(Pageable pageable);
     int bulkSync(List<CompanyRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/DailyExpenseService.java
+++ b/src/main/java/com/easyreach/backend/service/DailyExpenseService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface DailyExpenseService {
     ApiResponse<DailyExpenseResponseDto> create(DailyExpenseRequestDto dto);
@@ -15,4 +17,5 @@ public interface DailyExpenseService {
     ApiResponse<DailyExpenseResponseDto> get(String id);
     ApiResponse<Page<DailyExpenseResponseDto>> list(Pageable pageable);
     int bulkSync(List<DailyExpenseRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/DieselUsageService.java
+++ b/src/main/java/com/easyreach/backend/service/DieselUsageService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface DieselUsageService {
     ApiResponse<DieselUsageResponseDto> create(DieselUsageRequestDto dto);
@@ -15,4 +17,5 @@ public interface DieselUsageService {
     ApiResponse<DieselUsageResponseDto> get(String id);
     ApiResponse<Page<DieselUsageResponseDto>> list(Pageable pageable);
     int bulkSync(List<DieselUsageRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/EquipmentUsageService.java
+++ b/src/main/java/com/easyreach/backend/service/EquipmentUsageService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface EquipmentUsageService {
     ApiResponse<EquipmentUsageResponseDto> create(EquipmentUsageRequestDto dto);
@@ -15,4 +17,5 @@ public interface EquipmentUsageService {
     ApiResponse<EquipmentUsageResponseDto> get(String id);
     ApiResponse<Page<EquipmentUsageResponseDto>> list(Pageable pageable);
     int bulkSync(List<EquipmentUsageRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/ExpenseMasterService.java
+++ b/src/main/java/com/easyreach/backend/service/ExpenseMasterService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface ExpenseMasterService {
     ApiResponse<ExpenseMasterResponseDto> create(ExpenseMasterRequestDto dto);
@@ -15,4 +17,5 @@ public interface ExpenseMasterService {
     ApiResponse<ExpenseMasterResponseDto> get(String id);
     ApiResponse<Page<ExpenseMasterResponseDto>> list(Pageable pageable);
     int bulkSync(List<ExpenseMasterRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/InternalVehicleService.java
+++ b/src/main/java/com/easyreach/backend/service/InternalVehicleService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface InternalVehicleService {
     ApiResponse<InternalVehicleResponseDto> create(InternalVehicleRequestDto dto);
@@ -15,4 +17,5 @@ public interface InternalVehicleService {
     ApiResponse<InternalVehicleResponseDto> get(String id);
     ApiResponse<Page<InternalVehicleResponseDto>> list(Pageable pageable);
     int bulkSync(List<InternalVehicleRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/PayerService.java
+++ b/src/main/java/com/easyreach/backend/service/PayerService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface PayerService {
     ApiResponse<PayerResponseDto> create(PayerRequestDto dto);
@@ -15,4 +17,5 @@ public interface PayerService {
     ApiResponse<PayerResponseDto> get(String id);
     ApiResponse<Page<PayerResponseDto>> list(Pageable pageable);
     int bulkSync(List<PayerRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/PayerSettlementService.java
+++ b/src/main/java/com/easyreach/backend/service/PayerSettlementService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface PayerSettlementService {
     ApiResponse<PayerSettlementResponseDto> create(PayerSettlementRequestDto dto);
@@ -15,4 +17,5 @@ public interface PayerSettlementService {
     ApiResponse<PayerSettlementResponseDto> get(String id);
     ApiResponse<Page<PayerSettlementResponseDto>> list(Pageable pageable);
     int bulkSync(List<PayerSettlementRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/UserService.java
+++ b/src/main/java/com/easyreach/backend/service/UserService.java
@@ -6,10 +6,14 @@ import com.easyreach.backend.dto.users.UserResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.OffsetDateTime;
+import java.util.Map;
+
 public interface UserService {
     ApiResponse<UserResponseDto> create(UserRequestDto dto);
     ApiResponse<UserResponseDto> update(String id, UserRequestDto dto);
     ApiResponse<Void> delete(String id);
     ApiResponse<UserResponseDto> get(String id);
     ApiResponse<Page<UserResponseDto>> list(Pageable pageable);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/VehicleEntryService.java
+++ b/src/main/java/com/easyreach/backend/service/VehicleEntryService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface VehicleEntryService {
     ApiResponse<VehicleEntryResponseDto> create(VehicleEntryRequestDto dto);
@@ -15,4 +17,5 @@ public interface VehicleEntryService {
     ApiResponse<VehicleEntryResponseDto> get(String id);
     ApiResponse<Page<VehicleEntryResponseDto>> list(Pageable pageable);
     int bulkSync(List<VehicleEntryRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/VehicleTypeService.java
+++ b/src/main/java/com/easyreach/backend/service/VehicleTypeService.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.time.OffsetDateTime;
 
 public interface VehicleTypeService {
     ApiResponse<VehicleTypeResponseDto> create(VehicleTypeRequestDto dto);
@@ -15,4 +17,5 @@ public interface VehicleTypeService {
     ApiResponse<VehicleTypeResponseDto> get(String id);
     ApiResponse<Page<VehicleTypeResponseDto>> list(Pageable pageable);
     int bulkSync(List<VehicleTypeRequestDto> dtos);
+    Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit);
 }

--- a/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.CompanyService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class CompanyServiceImpl implements CompanyService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class CompanyServiceImpl implements CompanyService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<Company> updates = repository.findByUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(Company::getUuid).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.DailyExpenseService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<DailyExpense> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(DailyExpense::getExpenseId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/DieselUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DieselUsageServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.DieselUsageService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class DieselUsageServiceImpl implements DieselUsageService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class DieselUsageServiceImpl implements DieselUsageService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<DieselUsage> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(DieselUsage::getDieselUsageId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.EquipmentUsageService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<EquipmentUsage> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(EquipmentUsage::getEquipmentUsageId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.ExpenseMasterService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<ExpenseMaster> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(ExpenseMaster::getId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.PayerService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class PayerServiceImpl implements PayerService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class PayerServiceImpl implements PayerService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<Payer> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(Payer::getPayerId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.PayerSettlementService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class PayerSettlementServiceImpl implements PayerSettlementService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class PayerSettlementServiceImpl implements PayerSettlementService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<PayerSettlement> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(PayerSettlement::getSettlementId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.VehicleEntryService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class VehicleEntryServiceImpl implements VehicleEntryService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class VehicleEntryServiceImpl implements VehicleEntryService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<VehicleEntry> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(VehicleEntry::getEntryId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
@@ -10,6 +10,7 @@ import com.easyreach.backend.service.VehicleTypeService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,6 +78,7 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
+                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {
@@ -89,5 +91,20 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
         }
         repository.saveAll(entities);
         return entities.size();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
+        Map<String, Object> result = new HashMap<>();
+        List<VehicleType> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
+        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        int remaining = limit - updates.size();
+        List<String> tombstones = remaining > 0
+                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
+                .stream().map(VehicleType::getId).toList()
+                : Collections.emptyList();
+        result.put("tombstones", tombstones);
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
- add synchronization query methods to all repositories
- expose fetchChangesSince in domain services and handle tombstones
- increment changeId and update timestamps during bulkSync

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fb9d9534832db362ba7c220dad5b