### PR TITLE
feat: add sync download DTO and service stub

### DIFF
--- a/src/main/java/com/easyreach/backend/controller/SyncController.java
+++ b/src/main/java/com/easyreach/backend/controller/SyncController.java
@@ -1,6 +1,7 @@
 package com.easyreach.backend.controller;
 
 import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.SyncDownloadResponseDto;
 import com.easyreach.backend.dto.SyncRequestDto;
 import com.easyreach.backend.dto.SyncResponseDto;
 import com.easyreach.backend.service.*;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.time.OffsetDateTime;
 
 @RestController
 @RequestMapping("/api")
@@ -26,6 +28,7 @@ public class SyncController {
     private final PayerSettlementService payerSettlementService;
     private final VehicleEntryService vehicleEntryService;
     private final VehicleTypeService vehicleTypeService;
+    private final SyncService syncService;
 
     @PostMapping("/sync")
     @Operation(summary = "Bulk synchronize entities", description = "Accepts lists of entity DTOs and persists them with isSynced=true")
@@ -62,6 +65,14 @@ public class SyncController {
             response.setVehicleTypes(vehicleTypeService.bulkSync(request.getVehicleTypes()));
         }
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/sync/download")
+    @Operation(summary = "Download changes since cursor")
+    public ResponseEntity<ApiResponse<SyncDownloadResponseDto>> download(
+            @RequestParam(required = false) OffsetDateTime cursor,
+            @RequestParam(defaultValue = "100") int limit) {
+        return ResponseEntity.ok(ApiResponse.success(syncService.download(cursor, limit)));
     }
 }
 

--- a/src/main/java/com/easyreach/backend/dto/SyncDownloadResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/SyncDownloadResponseDto.java
@@ -1,0 +1,15 @@
+package com.easyreach.backend.dto;
+
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class SyncDownloadResponseDto {
+    private Map<String, List<?>> items;
+    private Map<String, List<TombstoneDto>> tombstones;
+    private OffsetDateTime cursorEnd;
+    private boolean hasMore;
+}

--- a/src/main/java/com/easyreach/backend/dto/TombstoneDto.java
+++ b/src/main/java/com/easyreach/backend/dto/TombstoneDto.java
@@ -1,0 +1,15 @@
+package com.easyreach.backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TombstoneDto {
+    private String id;
+    private OffsetDateTime deletedAt;
+}

--- a/src/main/java/com/easyreach/backend/service/SyncService.java
+++ b/src/main/java/com/easyreach/backend/service/SyncService.java
@@ -1,0 +1,9 @@
+package com.easyreach.backend.service;
+
+import com.easyreach.backend.dto.SyncDownloadResponseDto;
+
+import java.time.OffsetDateTime;
+
+public interface SyncService {
+    SyncDownloadResponseDto download(OffsetDateTime cursor, int limit);
+}

--- a/src/main/java/com/easyreach/backend/service/impl/SyncServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/SyncServiceImpl.java
@@ -1,0 +1,25 @@
+package com.easyreach.backend.service.impl;
+
+import com.easyreach.backend.dto.SyncDownloadResponseDto;
+import com.easyreach.backend.service.SyncService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SyncServiceImpl implements SyncService {
+    @Override
+    public SyncDownloadResponseDto download(OffsetDateTime cursor, int limit) {
+        SyncDownloadResponseDto response = new SyncDownloadResponseDto();
+        response.setItems(Collections.emptyMap());
+        response.setTombstones(Collections.emptyMap());
+        response.setCursorEnd(cursor);
+        response.setHasMore(false);
+        return response;
+    }
+}

--- a/src/test/java/com/easyreach/backend/controller/SyncControllerTest.java
+++ b/src/test/java/com/easyreach/backend/controller/SyncControllerTest.java
@@ -41,6 +41,7 @@ class SyncControllerTest {
     @MockBean private PayerSettlementService payerSettlementService;
     @MockBean private VehicleEntryService vehicleEntryService;
     @MockBean private VehicleTypeService vehicleTypeService;
+    @MockBean private SyncService syncService;
 
     private CompanyRequestDto sampleCompany() {
         return new CompanyRequestDto(


### PR DESCRIPTION
## Summary
- add SyncDownloadResponseDto and TombstoneDto models
- introduce SyncService and stub implementation
- extend SyncController with download endpoint
- adjust SyncControllerTest for new service

## Testing
- `mvn -q -T 1C test` *(fails: Non-resolvable parent POM for com.easyreach:easyreach-backend:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fba38a8c832d8a1e260fd7c8ec36