### PR TITLE
Refine incremental sync pagination

### DIFF
--- a/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
@@ -97,14 +97,39 @@ public class CompanyServiceImpl implements CompanyService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<Company> updates = repository.findByUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<Company> updates = repository.findByUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(Company::getUuid).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<Company> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(Company::getUuid).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (Company e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (Company e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
@@ -97,14 +97,39 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<DailyExpense> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<DailyExpense> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(DailyExpense::getExpenseId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<DailyExpense> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(DailyExpense::getExpenseId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (DailyExpense e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (DailyExpense e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
@@ -97,14 +97,39 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<EquipmentUsage> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<EquipmentUsage> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(EquipmentUsage::getEquipmentUsageId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<EquipmentUsage> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(EquipmentUsage::getEquipmentUsageId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (EquipmentUsage e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (EquipmentUsage e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
@@ -97,14 +97,39 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<ExpenseMaster> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<ExpenseMaster> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(ExpenseMaster::getId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<ExpenseMaster> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(ExpenseMaster::getId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (ExpenseMaster e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (ExpenseMaster e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
@@ -97,14 +97,39 @@ public class InternalVehicleServiceImpl implements InternalVehicleService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<InternalVehicle> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<InternalVehicle> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(InternalVehicle::getVehicleId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<InternalVehicle> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(InternalVehicle::getVehicleId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (InternalVehicle e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (InternalVehicle e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
@@ -97,14 +97,39 @@ public class PayerServiceImpl implements PayerService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<Payer> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<Payer> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(Payer::getPayerId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<Payer> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(Payer::getPayerId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (Payer e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (Payer e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
@@ -97,14 +97,39 @@ public class PayerSettlementServiceImpl implements PayerSettlementService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<PayerSettlement> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<PayerSettlement> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(PayerSettlement::getSettlementId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<PayerSettlement> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(PayerSettlement::getSettlementId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (PayerSettlement e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (PayerSettlement e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/SyncDownloadServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/SyncDownloadServiceImpl.java
@@ -89,28 +89,22 @@ public class SyncDownloadServiceImpl implements SyncDownloadService {
                 continue;
             }
 
-            List<?> items = (List<?>) data.getOrDefault("updated", Collections.emptyList());
+            List<?> items = (List<?>) data.getOrDefault("items", Collections.emptyList());
             List<?> tombstones = (List<?>) data.getOrDefault("tombstones", Collections.emptyList());
+            OffsetDateTime entityCursorEnd = (OffsetDateTime) data.getOrDefault("cursorEnd", cursor);
+            boolean entityHasMore = (boolean) data.getOrDefault("hasMore", false);
 
             Map<String, Object> perEntity = new HashMap<>();
             perEntity.put("items", items);
             perEntity.put("tombstones", tombstones);
+            perEntity.put("cursorEnd", entityCursorEnd);
+            perEntity.put("hasMore", entityHasMore);
             response.put(entity, perEntity);
 
-            for (Object item : items) {
-                OffsetDateTime ts = extractTimestamp(item);
-                if (ts != null && ts.isAfter(cursorEnd)) {
-                    cursorEnd = ts;
-                }
+            if (entityCursorEnd != null && entityCursorEnd.isAfter(cursorEnd)) {
+                cursorEnd = entityCursorEnd;
             }
-            for (Object tombstone : tombstones) {
-                OffsetDateTime ts = extractTimestamp(tombstone);
-                if (ts != null && ts.isAfter(cursorEnd)) {
-                    cursorEnd = ts;
-                }
-            }
-
-            if (items.size() + tombstones.size() >= fetchLimit) {
+            if (entityHasMore) {
                 hasMore = true;
             }
         }

--- a/src/main/java/com/easyreach/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/UserServiceImpl.java
@@ -61,14 +61,39 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<User> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<User> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(User::getId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<User> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(User::getId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (User e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (User e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
@@ -97,14 +97,39 @@ public class VehicleEntryServiceImpl implements VehicleEntryService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<VehicleEntry> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<VehicleEntry> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(VehicleEntry::getEntryId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<VehicleEntry> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(VehicleEntry::getEntryId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (VehicleEntry e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (VehicleEntry e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
@@ -97,14 +97,39 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
     @Transactional(readOnly = true)
     public Map<String, Object> fetchChangesSince(String companyUuid, OffsetDateTime cursor, int limit) {
         Map<String, Object> result = new HashMap<>();
-        List<VehicleType> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, limit));
-        result.put("updated", updates.stream().map(mapper::toDto).toList());
+        boolean hasMore = false;
+
+        List<VehicleType> updates = repository.findByCompanyUuidAndUpdatedAtGreaterThanEqual(
+                companyUuid, cursor, PageRequest.of(0, limit + 1));
+        if (updates.size() > limit) {
+            hasMore = true;
+            updates = updates.subList(0, limit);
+        }
+        result.put("items", updates.stream().map(mapper::toDto).toList());
+
         int remaining = limit - updates.size();
-        List<String> tombstones = remaining > 0
-                ? repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(companyUuid, cursor, PageRequest.of(0, remaining))
-                .stream().map(VehicleType::getId).toList()
-                : Collections.emptyList();
-        result.put("tombstones", tombstones);
+        List<VehicleType> tombstoneEntities = Collections.emptyList();
+        if (remaining > 0) {
+            tombstoneEntities = repository.findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(
+                    companyUuid, cursor, PageRequest.of(0, remaining + 1));
+            if (tombstoneEntities.size() > remaining) {
+                hasMore = true;
+                tombstoneEntities = tombstoneEntities.subList(0, remaining);
+            }
+        }
+        result.put("tombstones", tombstoneEntities.stream().map(VehicleType::getId).toList());
+
+        OffsetDateTime cursorEnd = cursor;
+        for (VehicleType e : updates) {
+            OffsetDateTime ts = e.getUpdatedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        for (VehicleType e : tombstoneEntities) {
+            OffsetDateTime ts = e.getDeletedAt();
+            if (ts != null && ts.isAfter(cursorEnd)) cursorEnd = ts;
+        }
+        result.put("cursorEnd", cursorEnd);
+        result.put("hasMore", hasMore);
         return result;
     }
 }


### PR DESCRIPTION
## Summary
- Enhance `fetchChangesSince` across service implementations to page with `limit + 1` queries, handle tombstones, compute `cursorEnd`, and expose `hasMore` metadata
- Update `SyncDownloadServiceImpl` to consume the new structured response from individual services

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*


------
https://chatgpt.com/codex/tasks/task_e_68b40889c250832d8eb9526b3cec31c5