### PR TITLE
Externalize credentials and add deployment configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Multi-stage build for the EasyReach backend
+
+# ---- Build stage ----
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+
+# Cache dependencies
+COPY pom.xml .
+RUN mvn -q dependency:go-offline
+
+# Copy source and build
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+# ---- Runtime stage ----
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+COPY --from=build /app/target/*.jar app.jar
+
+# Expect credentials to be supplied at runtime
+ENV DB_URL=""
+ENV DB_USERNAME=""
+ENV DB_PASSWORD=""
+ENV JWT_SECRET=""
+
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]
+

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,16 @@
+services:
+  - type: web
+    name: easyreach-be
+    env: java
+    buildCommand: mvn -q package -DskipTests
+    startCommand: java -jar target/*.jar
+    envVars:
+      - key: DB_URL
+        sync: false
+      - key: DB_USERNAME
+        sync: false
+      - key: DB_PASSWORD
+        sync: false
+      - key: JWT_SECRET
+        sync: false
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,9 @@ server:
 
 spring:
   datasource:
-    url: jdbc:postgresql://dpg-d2ioktje5dus73b8gv9g-a.singapore-postgres.render.com:5432/easyreach_db?sslmode=require&application_name=easyreach
-    username: easyreach_db_user
-    password: WHqcz59yKp5km8BN0t6K1fsjSCKhxKnu
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
     # --- HikariCP tuning (all in milliseconds) ---
@@ -40,7 +40,7 @@ springdoc:
     path: /swagger-ui.html
 
 jwt:
-  secret-base64: ls5XjEgc1ZX71gWfnEFtLfVaZZNmc4ajasvvm1mw0Q4=
+  secret-base64: ${JWT_SECRET}
   access-token:
     ttl-minutes: 15
   refresh-token:


### PR DESCRIPTION
## Summary
- read database and JWT secrets from environment
- add Dockerfile and Render deployment configuration with env placeholders

## Testing
- `DB_URL=jdbc:postgresql://localhost:5432/test DB_USERNAME=user DB_PASSWORD=pass JWT_SECRET=test mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b40e332e58832da2a4ba80918081dc