### PR TITLE
Decode JWT secret and configure token TTL

### DIFF
--- a/src/test/java/com/easyreach/backend/security/JwtServiceTest.java
+++ b/src/test/java/com/easyreach/backend/security/JwtServiceTest.java
@@ -13,6 +13,8 @@ public class JwtServiceTest {
     void setUp() {
         service = new JwtService();
         ReflectionTestUtils.setField(service, "secretBase64", "123456789012345678901234567890123456789012345678901234567890");
+        ReflectionTestUtils.setField(service, "accessTtlMinutes", 15L);
+        ReflectionTestUtils.setField(service, "refreshTtlDays", 7L);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Decode JWT signing secret using `Decoders.BASE64` instead of UTF-8 bytes
- Make access and refresh token TTLs configurable via `application.yml`
- Update tests to configure new TTL fields

## Testing
- `mvn test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b40f50da78832db37def421a8bccad