### PR TITLE
Add JPA auditing and clean up user request DTO

### DIFF
--- a/src/main/java/com/easyreach/backend/dto/users/UserRequestDto.java
+++ b/src/main/java/com/easyreach/backend/dto/users/UserRequestDto.java
@@ -3,7 +3,6 @@ package com.easyreach.backend.dto.users;
 import lombok.*;
 import jakarta.validation.constraints.*;
 import java.time.*;
-import java.math.*;
 
 @Data
 @NoArgsConstructor
@@ -37,15 +36,4 @@ public class UserRequestDto {
   private LocalDate joiningDate;
   @NotNull
   private Boolean isActive;
-  @NotNull
-  private OffsetDateTime createdAt;
-  @NotNull
-  private OffsetDateTime updatedAt;
-
-  @NotNull
-  private Boolean deleted;
-
-  private OffsetDateTime deletedAt;
-
-  private Long changeId;
 }

--- a/src/main/java/com/easyreach/backend/entity/User.java
+++ b/src/main/java/com/easyreach/backend/entity/User.java
@@ -1,6 +1,5 @@
 package com.easyreach.backend.entity;
 
-import com.easyreach.backend.auth.entity.Role;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
@@ -54,8 +53,9 @@ public class User implements UserDetails {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
+    @Builder.Default
     @Column(name = "deleted", nullable = false)
-    private boolean deleted;
+    private boolean deleted = false;
 
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
@@ -92,5 +92,18 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+        this.deleted = false;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
     }
 }

--- a/src/main/java/com/easyreach/backend/mapper/UserMapper.java
+++ b/src/main/java/com/easyreach/backend/mapper/UserMapper.java
@@ -7,14 +7,8 @@ import com.easyreach.backend.dto.users.UserResponseDto;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
-    @Mapping(target = "deleted", source = "deleted")
-    @Mapping(target = "deletedAt", source = "deletedAt")
-    @Mapping(target = "changeId", source = "changeId")
     User toEntity(UserRequestDto dto);
 
-    @Mapping(target = "deleted", source = "deleted")
-    @Mapping(target = "deletedAt", source = "deletedAt")
-    @Mapping(target = "changeId", source = "changeId")
     UserResponseDto toDto(User entity);
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)


### PR DESCRIPTION
## Summary
- remove audit fields from UserRequestDto
- add JPA lifecycle callbacks to set createdAt and updatedAt
- default the deleted flag to false in User entity

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b411a717f4832d822c996e61778a6f