### PR TITLE
Align baseline migration with entity mappings

### DIFF
--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,21 +1,21 @@
 CREATE TABLE public.companies (
     uuid text NOT NULL,
-    company_id character varying(50),
-    companyname character varying(30) NOT NULL,
-    companycontactno character varying(20) NOT NULL,
-    companycoordinates character varying(100),
-    companylocation character varying(50) NOT NULL,
-    companyregistrationdate date NOT NULL,
-    ownername character varying(20) NOT NULL,
-    ownermobileno character varying(20) NOT NULL,
-    owneremailaddress character varying(50) NOT NULL,
-    ownerdob date NOT NULL,
-    isactive integer DEFAULT 1,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    company_code character varying(50) NOT NULL,
+    company_name character varying(30) NOT NULL,
+    company_contact_no character varying(20) NOT NULL,
+    company_coordinates character varying(100),
+    company_location character varying(50) NOT NULL,
+    company_registration_date date NOT NULL,
+    owner_name character varying(20) NOT NULL,
+    owner_mobile_no character varying(20) NOT NULL,
+    owner_email_address character varying(50) NOT NULL,
+    owner_dob date NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -28,17 +28,22 @@ CREATE SEQUENCE public.companies_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.companies_change_id_seq OWNED BY public.companies.change_id;
 CREATE TABLE public.daily_expenses (
-    expenseid character varying(20) NOT NULL,
-    expensetype character varying(30) NOT NULL,
-    expenseamount numeric(10,2) NOT NULL,
-    expensedate timestamp without time zone NOT NULL,
-    expensenote text,
+    "expenseId" character varying(20) NOT NULL,
+    expense_type character varying(30) NOT NULL,
+    expense_amount numeric(10,2) NOT NULL,
+    expense_date timestamp without time zone NOT NULL,
+    expense_note text,
+    is_paid boolean DEFAULT false NOT NULL,
+    paid_by character varying(50),
+    paid_to character varying(50),
+    paid_date timestamp without time zone,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    user_id character varying(50),
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -51,16 +56,16 @@ CREATE SEQUENCE public.daily_expenses_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.daily_expenses_change_id_seq OWNED BY public.daily_expenses.change_id;
 CREATE TABLE public.diesel_usage (
-    dieselusageid character varying(20) NOT NULL,
-    vehiclename character varying(30) NOT NULL,
+    "dieselUsageId" character varying(20) NOT NULL,
+    vehicle_name character varying(30) NOT NULL,
     date timestamp without time zone NOT NULL,
     liters numeric(10,2) NOT NULL,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -73,20 +78,20 @@ CREATE SEQUENCE public.diesel_usage_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.diesel_usage_change_id_seq OWNED BY public.diesel_usage.change_id;
 CREATE TABLE public.equipment_usage (
-    equipmentusageid character varying(20) NOT NULL,
-    equipmentname character varying(30) NOT NULL,
-    equipmenttype character varying(15) NOT NULL,
-    startkm numeric(10,2) NOT NULL,
-    endkm numeric(10,2) NOT NULL,
-    starttime timestamp without time zone NOT NULL,
-    endtime timestamp without time zone NOT NULL,
+    "equipmentUsageId" character varying(20) NOT NULL,
+    equipment_name character varying(30) NOT NULL,
+    equipment_type character varying(15) NOT NULL,
+    start_km numeric(10,2) NOT NULL,
+    end_km numeric(10,2) NOT NULL,
+    start_time timestamp without time zone NOT NULL,
+    end_time timestamp without time zone NOT NULL,
     date timestamp without time zone NOT NULL,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -100,13 +105,13 @@ CREATE SEQUENCE public.equipment_usage_change_id_seq
 ALTER SEQUENCE public.equipment_usage_change_id_seq OWNED BY public.equipment_usage.change_id;
 CREATE TABLE public.expense_master (
     id character varying(20) NOT NULL,
-    expensename character varying(20) NOT NULL,
+    expense_name character varying(20) NOT NULL,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -119,16 +124,16 @@ CREATE SEQUENCE public.expense_master_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.expense_master_change_id_seq OWNED BY public.expense_master.change_id;
 CREATE TABLE public.internal_vehicles (
-    vehicleid character varying(20) NOT NULL,
-    vehiclename character varying(30) NOT NULL,
-    vehicletype character varying(15) NOT NULL,
-    isactive integer DEFAULT 1,
+    "vehicleId" character varying(20) NOT NULL,
+    vehicle_name character varying(30) NOT NULL,
+    vehicle_type character varying(15) NOT NULL,
+    is_active boolean DEFAULT true NOT NULL,
     company_uuid character varying(50),
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -141,16 +146,16 @@ CREATE SEQUENCE public.internal_vehicles_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.internal_vehicles_change_id_seq OWNED BY public.internal_vehicles.change_id;
 CREATE TABLE public.payer_settlements (
-    settlementid character varying(20) NOT NULL,
-    payerid character varying(20) NOT NULL,
+    "settlementId" character varying(20) NOT NULL,
+    payer_id character varying(20) NOT NULL,
     amount numeric(10,2) NOT NULL,
     date timestamp without time zone NOT NULL,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -163,18 +168,18 @@ CREATE SEQUENCE public.payer_settlements_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.payer_settlements_change_id_seq OWNED BY public.payer_settlements.change_id;
 CREATE TABLE public.payers (
-    payerid character varying(20) NOT NULL,
-    payername character varying(30) NOT NULL,
-    mobileno character varying(20) NOT NULL,
-    payeraddress character varying(100),
-    registrationdate date,
-    creditlimit integer DEFAULT 0,
+    "payerId" character varying(20) NOT NULL,
+    payer_name character varying(30) NOT NULL,
+    mobile_no character varying(20) NOT NULL,
+    payer_address character varying(100),
+    registration_date date,
+    credit_limit integer DEFAULT 0,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -201,19 +206,21 @@ CREATE TABLE public.refresh_token (
 );
 CREATE TABLE public.users (
     id text NOT NULL,
-    uuid text,
-    employeeid character varying(50) NOT NULL,
+    employee_id character varying(50) NOT NULL,
     email character varying(100),
-    mobileno character varying(20),
+    mobile_no character varying(20),
     password character varying(255),
     role character varying(30),
     name character varying(100),
     company_uuid character varying(50),
-    createdby character varying(50),
+    company_code character varying(50),
+    created_by character varying(50),
     location character varying(100),
-    dateofbirth date,
-    joiningdate date,
-    isactive integer DEFAULT 1,
+    date_of_birth date,
+    joining_date date,
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -226,35 +233,35 @@ CREATE SEQUENCE public.users_change_id_seq
     CACHE 1;
 ALTER SEQUENCE public.users_change_id_seq OWNED BY public.users.change_id;
 CREATE TABLE public.vehicle_entries (
-    entryid character varying(20) NOT NULL,
+    "entryId" character varying(20) NOT NULL,
     company_uuid character varying(50) NOT NULL,
-    payerid character varying(20) NOT NULL,
-    vehiclenumber character varying(15) NOT NULL,
-    vehicletype character varying(15) NOT NULL,
-    fromaddress character varying(50) NOT NULL,
-    toaddress character varying(50) NOT NULL,
-    drivername character varying(20) NOT NULL,
-    drivercontactno character varying(20) NOT NULL,
+    payer_id character varying(20) NOT NULL,
+    vehicle_number character varying(15) NOT NULL,
+    vehicle_type character varying(15) NOT NULL,
+    from_address character varying(50) NOT NULL,
+    to_address character varying(50) NOT NULL,
+    driver_name character varying(20) NOT NULL,
+    driver_contact_no character varying(20) NOT NULL,
     commission numeric(10,2) NOT NULL,
     beta numeric(10,2) NOT NULL,
-    refferedby character varying(20),
+    referred_by character varying(20),
     amount numeric(10,2) NOT NULL,
     paytype character varying(10) NOT NULL,
-    entrydate date NOT NULL,
-    entrytime timestamp without time zone NOT NULL,
-    exittime timestamp without time zone,
+    entry_date date NOT NULL,
+    entry_time timestamp without time zone NOT NULL,
+    exit_time timestamp without time zone,
     notes text,
-    paymentreceivedby character varying(50),
-    paidamount numeric(10,2) NOT NULL,
-    pendingamt numeric(10,2) NOT NULL,
-    issettled integer DEFAULT 0,
-    settlementtype character varying(15),
-    settlementdate timestamp without time zone,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    payment_received_by character varying(50),
+    paid_amount numeric(10,2) NOT NULL,
+    pending_amt numeric(10,2) NOT NULL,
+    is_settled boolean DEFAULT false NOT NULL,
+    settlement_type character varying(15),
+    settlement_date timestamp without time zone,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -268,14 +275,14 @@ CREATE SEQUENCE public.vehicle_entries_change_id_seq
 ALTER SEQUENCE public.vehicle_entries_change_id_seq OWNED BY public.vehicle_entries.change_id;
 CREATE TABLE public.vehicle_types (
     id character varying(20) NOT NULL,
-    vehicletype character varying(30) NOT NULL,
+    vehicle_type character varying(30) NOT NULL,
     type character varying(10) NOT NULL,
     company_uuid character varying(50) NOT NULL,
-    issynced integer DEFAULT 0,
-    createdby character varying(50),
-    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
-    updatedby character varying(50),
-    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP,
+    is_synced boolean DEFAULT false NOT NULL,
+    created_by character varying(50),
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_by character varying(50),
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     deleted boolean DEFAULT false NOT NULL,
     deleted_at timestamp with time zone,
     change_id bigint NOT NULL
@@ -299,35 +306,33 @@ ALTER TABLE ONLY public.users ALTER COLUMN change_id SET DEFAULT nextval('public
 ALTER TABLE ONLY public.vehicle_entries ALTER COLUMN change_id SET DEFAULT nextval('public.vehicle_entries_change_id_seq'::regclass);
 ALTER TABLE ONLY public.vehicle_types ALTER COLUMN change_id SET DEFAULT nextval('public.vehicle_types_change_id_seq'::regclass);
 ALTER TABLE ONLY public.companies
-    ADD CONSTRAINT companies_companyid_key UNIQUE (company_id);
+    ADD CONSTRAINT companies_company_code_key UNIQUE (company_code);
 ALTER TABLE ONLY public.companies
     ADD CONSTRAINT companies_pkey PRIMARY KEY (uuid);
 ALTER TABLE ONLY public.daily_expenses
-    ADD CONSTRAINT daily_expenses_pkey PRIMARY KEY (expenseid);
+    ADD CONSTRAINT daily_expenses_pkey PRIMARY KEY ("expenseId");
 ALTER TABLE ONLY public.diesel_usage
-    ADD CONSTRAINT diesel_usage_pkey PRIMARY KEY (dieselusageid);
+    ADD CONSTRAINT diesel_usage_pkey PRIMARY KEY ("dieselUsageId");
 ALTER TABLE ONLY public.equipment_usage
-    ADD CONSTRAINT equipment_usage_pkey PRIMARY KEY (equipmentusageid);
+    ADD CONSTRAINT equipment_usage_pkey PRIMARY KEY ("equipmentUsageId");
 ALTER TABLE ONLY public.expense_master
     ADD CONSTRAINT expense_master_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY public.internal_vehicles
-    ADD CONSTRAINT internal_vehicles_pkey PRIMARY KEY (vehicleid);
+    ADD CONSTRAINT internal_vehicles_pkey PRIMARY KEY ("vehicleId");
 ALTER TABLE ONLY public.payer_settlements
-    ADD CONSTRAINT payer_settlements_pkey PRIMARY KEY (settlementid);
+    ADD CONSTRAINT payer_settlements_pkey PRIMARY KEY ("settlementId");
 ALTER TABLE ONLY public.payers
-    ADD CONSTRAINT payers_pkey PRIMARY KEY (payerid);
+    ADD CONSTRAINT payers_pkey PRIMARY KEY ("payerId");
 ALTER TABLE ONLY public.refresh_token
     ADD CONSTRAINT refresh_token_pkey PRIMARY KEY (jti);
 ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_companyid_employeeid_key UNIQUE (company_uuid, employeeid);
+    ADD CONSTRAINT users_company_uuid_employee_id_key UNIQUE (company_uuid, employee_id);
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_email_key UNIQUE (email);
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
-ALTER TABLE ONLY public.users
-    ADD CONSTRAINT users_uuid_key UNIQUE (uuid);
 ALTER TABLE ONLY public.vehicle_entries
-    ADD CONSTRAINT vehicle_entries_pkey PRIMARY KEY (entryid);
+    ADD CONSTRAINT vehicle_entries_pkey PRIMARY KEY ("entryId");
 ALTER TABLE ONLY public.vehicle_types
     ADD CONSTRAINT vehicle_types_pkey PRIMARY KEY (id);
 CREATE INDEX idx_companies_uuid_deleted_deleted_at ON public.companies USING btree (uuid, deleted, deleted_at);


### PR DESCRIPTION
## Summary
- Rename columns in V1__baseline.sql to match JPA entity annotations
- Add missing fields (payments, user links, timestamps) and convert numeric flags to booleans
- Update primary key and unique constraints to reflect entity expectations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b417f5a898832da9a6f840d83b6524