### PR TITLE
Configure OpenAPI for JWT bearer authentication

### DIFF
--- a/src/main/java/com/easyreach/backend/config/OpenApiConfig.java
+++ b/src/main/java/com/easyreach/backend/config/OpenApiConfig.java
@@ -2,6 +2,9 @@ package com.easyreach.backend.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,6 +12,16 @@ import org.springframework.context.annotation.Configuration;
 public class OpenApiConfig {
     @Bean
     public OpenAPI openAPI() {
-        return new OpenAPI().info(new Info().title("Easyreach API").version("v1"));
+        final String schemeName = "bearerAuth";
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .info(new Info().title("Easyreach API").version("v1"))
+                .components(new Components().addSecuritySchemes(schemeName, securityScheme))
+                .addSecurityItem(new SecurityRequirement().addList(schemeName));
     }
 }


### PR DESCRIPTION
## Summary
- add OpenAPI security scheme for bearer JWT and apply global requirement

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4258fec60832dafc0382c0f922bdb