### PR TITLE
Annotate secured controllers with bearer auth

### DIFF
--- a/src/main/java/com/easyreach/backend/controller/CompanyController.java
+++ b/src/main/java/com/easyreach/backend/controller/CompanyController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.companies.CompanyResponseDto;
 import com.easyreach.backend.service.CompanyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/companies")
 @RequiredArgsConstructor
 @Tag(name="Company")
+@SecurityRequirement(name = "bearerAuth")
 public class CompanyController {
     private final CompanyService service;
 

--- a/src/main/java/com/easyreach/backend/controller/DailyExpenseController.java
+++ b/src/main/java/com/easyreach/backend/controller/DailyExpenseController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.daily_expenses.DailyExpenseResponseDto;
 import com.easyreach.backend.service.DailyExpenseService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/daily-expenses")
 @RequiredArgsConstructor
 @Tag(name="DailyExpense")
+@SecurityRequirement(name = "bearerAuth")
 public class DailyExpenseController {
     private final DailyExpenseService service;
 

--- a/src/main/java/com/easyreach/backend/controller/DieselUsageController.java
+++ b/src/main/java/com/easyreach/backend/controller/DieselUsageController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.diesel_usage.DieselUsageResponseDto;
 import com.easyreach.backend.service.DieselUsageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/diesel-usage")
 @RequiredArgsConstructor
 @Tag(name="DieselUsage")
+@SecurityRequirement(name = "bearerAuth")
 public class DieselUsageController {
     private final DieselUsageService service;
 

--- a/src/main/java/com/easyreach/backend/controller/EquipmentUsageController.java
+++ b/src/main/java/com/easyreach/backend/controller/EquipmentUsageController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.equipment_usage.EquipmentUsageResponseDto;
 import com.easyreach.backend.service.EquipmentUsageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/equipment-usage")
 @RequiredArgsConstructor
 @Tag(name="EquipmentUsage")
+@SecurityRequirement(name = "bearerAuth")
 public class EquipmentUsageController {
     private final EquipmentUsageService service;
 

--- a/src/main/java/com/easyreach/backend/controller/ExpenseMasterController.java
+++ b/src/main/java/com/easyreach/backend/controller/ExpenseMasterController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.expense_master.ExpenseMasterResponseDto;
 import com.easyreach.backend.service.ExpenseMasterService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/expense-master")
 @RequiredArgsConstructor
 @Tag(name="ExpenseMaster")
+@SecurityRequirement(name = "bearerAuth")
 public class ExpenseMasterController {
     private final ExpenseMasterService service;
 

--- a/src/main/java/com/easyreach/backend/controller/InternalVehicleController.java
+++ b/src/main/java/com/easyreach/backend/controller/InternalVehicleController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.internal_vehicles.InternalVehicleResponseDto;
 import com.easyreach.backend.service.InternalVehicleService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/internal-vehicles")
 @RequiredArgsConstructor
 @Tag(name="InternalVehicle")
+@SecurityRequirement(name = "bearerAuth")
 public class InternalVehicleController {
     private final InternalVehicleService service;
 

--- a/src/main/java/com/easyreach/backend/controller/PayerController.java
+++ b/src/main/java/com/easyreach/backend/controller/PayerController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.payers.PayerResponseDto;
 import com.easyreach.backend.service.PayerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/payers")
 @RequiredArgsConstructor
 @Tag(name="Payer")
+@SecurityRequirement(name = "bearerAuth")
 public class PayerController {
     private final PayerService service;
 

--- a/src/main/java/com/easyreach/backend/controller/PayerOpsController.java
+++ b/src/main/java/com/easyreach/backend/controller/PayerOpsController.java
@@ -5,6 +5,7 @@ import com.easyreach.backend.dto.payers.PayerResponseDto;
 import com.easyreach.backend.service.PayerQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/payers-ops")
 @RequiredArgsConstructor
 @Tag(name = "PayerOps")
+@SecurityRequirement(name = "bearerAuth")
 public class PayerOpsController {
 
     private final PayerQueryService service;

--- a/src/main/java/com/easyreach/backend/controller/PayerSettlementController.java
+++ b/src/main/java/com/easyreach/backend/controller/PayerSettlementController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.payer_settlements.PayerSettlementResponseDto;
 import com.easyreach.backend.service.PayerSettlementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/payer-settlements")
 @RequiredArgsConstructor
 @Tag(name="PayerSettlement")
+@SecurityRequirement(name = "bearerAuth")
 public class PayerSettlementController {
     private final PayerSettlementService service;
 

--- a/src/main/java/com/easyreach/backend/controller/SyncController.java
+++ b/src/main/java/com/easyreach/backend/controller/SyncController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api")
 @RequiredArgsConstructor
 @Tag(name = "Sync")
+@SecurityRequirement(name = "bearerAuth")
 public class SyncController {
     private final CompanyService companyService;
     private final DailyExpenseService dailyExpenseService;

--- a/src/main/java/com/easyreach/backend/controller/UserController.java
+++ b/src/main/java/com/easyreach/backend/controller/UserController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.users.UserResponseDto;
 import com.easyreach.backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 @Tag(name="User")
+@SecurityRequirement(name = "bearerAuth")
 public class UserController {
     private final UserService service;
 

--- a/src/main/java/com/easyreach/backend/controller/VehicleEntryController.java
+++ b/src/main/java/com/easyreach/backend/controller/VehicleEntryController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.vehicle_entries.VehicleEntryResponseDto;
 import com.easyreach.backend.service.VehicleEntryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/vehicle-entries")
 @RequiredArgsConstructor
 @Tag(name="VehicleEntry")
+@SecurityRequirement(name = "bearerAuth")
 public class VehicleEntryController {
     private final VehicleEntryService service;
 

--- a/src/main/java/com/easyreach/backend/controller/VehicleEntryOpsController.java
+++ b/src/main/java/com/easyreach/backend/controller/VehicleEntryOpsController.java
@@ -5,6 +5,7 @@ import com.easyreach.backend.dto.vehicle_entries.VehicleEntryResponseDto;
 import com.easyreach.backend.service.VehicleEntryOpsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import java.time.OffsetDateTime;
 @RequestMapping("/api/vehicle-entries-ops")
 @RequiredArgsConstructor
 @Tag(name = "VehicleEntryOps")
+@SecurityRequirement(name = "bearerAuth")
 public class VehicleEntryOpsController {
 
     private final VehicleEntryOpsService service;

--- a/src/main/java/com/easyreach/backend/controller/VehicleTypeController.java
+++ b/src/main/java/com/easyreach/backend/controller/VehicleTypeController.java
@@ -6,6 +6,7 @@ import com.easyreach.backend.dto.vehicle_types.VehicleTypeResponseDto;
 import com.easyreach.backend.service.VehicleTypeService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/vehicle-types")
 @RequiredArgsConstructor
 @Tag(name="VehicleType")
+@SecurityRequirement(name = "bearerAuth")
 public class VehicleTypeController {
     private final VehicleTypeService service;
 


### PR DESCRIPTION
## Summary
- Secure controller endpoints in Swagger by annotating classes with `@SecurityRequirement(name = "bearerAuth")`
- Leave RefreshTokenController public for unauthenticated access

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b425bb66d8832da3e7c76f900c3c2f