### PR TITLE
Restrict public endpoints to auth and docs

### DIFF
--- a/src/main/java/com/easyreach/backend/security/SecurityConfig.java
+++ b/src/main/java/com/easyreach/backend/security/SecurityConfig.java
@@ -31,12 +31,11 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/auth/**",
                                 "/api/auth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/api/**",
-                                "/auth/**"
+                                "/swagger-ui.html"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Summary
- Limit unauthenticated access to only authentication and Swagger documentation endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*
- `mvn -q spring-boot:run` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b425b83cc4832da8a3de534885b4ed