### PR TITLE
Remove manual changeId updates in service layer

### DIFF
--- a/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/CompanyServiceImpl.java
@@ -47,7 +47,6 @@ public class CompanyServiceImpl implements CompanyService {
                 .orElseThrow(() -> new EntityNotFoundException("Company not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class CompanyServiceImpl implements CompanyService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DailyExpenseServiceImpl.java
@@ -47,7 +47,6 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
                 .orElseThrow(() -> new EntityNotFoundException("DailyExpense not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class DailyExpenseServiceImpl implements DailyExpenseService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/DieselUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/DieselUsageServiceImpl.java
@@ -47,7 +47,6 @@ public class DieselUsageServiceImpl implements DieselUsageService {
                 .orElseThrow(() -> new EntityNotFoundException("DieselUsage not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class DieselUsageServiceImpl implements DieselUsageService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/EquipmentUsageServiceImpl.java
@@ -47,7 +47,6 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
                 .orElseThrow(() -> new EntityNotFoundException("EquipmentUsage not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class EquipmentUsageServiceImpl implements EquipmentUsageService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/ExpenseMasterServiceImpl.java
@@ -47,7 +47,6 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
                 .orElseThrow(() -> new EntityNotFoundException("ExpenseMaster not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class ExpenseMasterServiceImpl implements ExpenseMasterService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/InternalVehicleServiceImpl.java
@@ -47,7 +47,6 @@ public class InternalVehicleServiceImpl implements InternalVehicleService {
                 .orElseThrow(() -> new EntityNotFoundException("InternalVehicle not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class InternalVehicleServiceImpl implements InternalVehicleService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerServiceImpl.java
@@ -47,7 +47,6 @@ public class PayerServiceImpl implements PayerService {
                 .orElseThrow(() -> new EntityNotFoundException("Payer not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class PayerServiceImpl implements PayerService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/PayerSettlementServiceImpl.java
@@ -47,7 +47,6 @@ public class PayerSettlementServiceImpl implements PayerSettlementService {
                 .orElseThrow(() -> new EntityNotFoundException("PayerSettlement not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class PayerSettlementServiceImpl implements PayerSettlementService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/UserServiceImpl.java
@@ -44,7 +44,6 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new EntityNotFoundException("User not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleEntryServiceImpl.java
@@ -47,7 +47,6 @@ public class VehicleEntryServiceImpl implements VehicleEntryService {
                 .orElseThrow(() -> new EntityNotFoundException("VehicleEntry not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class VehicleEntryServiceImpl implements VehicleEntryService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {

--- a/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
+++ b/src/main/java/com/easyreach/backend/service/impl/VehicleTypeServiceImpl.java
@@ -47,7 +47,6 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
                 .orElseThrow(() -> new EntityNotFoundException("VehicleType not found: " + id));
         e.setDeleted(true);
         e.setDeletedAt(OffsetDateTime.now());
-        e.setChangeId(e.getChangeId() == null ? 0L : e.getChangeId() + 1);
         repository.save(e);
         return ApiResponse.success(null);
     }
@@ -84,7 +83,6 @@ public class VehicleTypeServiceImpl implements VehicleTypeService {
             if (entity != null) {
                 mapper.merge(dto, entity);
                 entity.setUpdatedAt(now);
-                entity.setChangeId(entity.getChangeId() == null ? 0L : entity.getChangeId() + 1);
                 entity.setIsSynced(true);
                 entities.add(entity);
             } else {


### PR DESCRIPTION
## Summary
- remove manual changeId increments from service implementations to let Hibernate @Version handle versioning

## Testing
- `mvn -q -e package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b426a7cd74832d88921c76d64fa37d