### PR TITLE
Enforce company-scoped requests with interceptor

### DIFF
--- a/src/main/java/com/easyreach/backend/config/WebConfig.java
+++ b/src/main/java/com/easyreach/backend/config/WebConfig.java
@@ -1,0 +1,27 @@
+package com.easyreach.backend.config;
+
+import com.easyreach.backend.security.CompanyInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final CompanyInterceptor companyInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(companyInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(
+                        "/auth/**",
+                        "/api/auth/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html"
+                );
+    }
+}
+

--- a/src/main/java/com/easyreach/backend/repository/VehicleTypeRepository.java
+++ b/src/main/java/com/easyreach/backend/repository/VehicleTypeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,7 +15,9 @@ public interface VehicleTypeRepository extends JpaRepository<VehicleType, String
 
     List<VehicleType> findByCompanyUuidAndDeletedIsTrueAndDeletedAtGreaterThanEqual(String companyUuid, OffsetDateTime cursor, Pageable pageable);
 
-    Optional<VehicleType> findByIdAndDeletedIsFalse(String id);
+    Optional<VehicleType> findByIdAndCompanyUuidAndDeletedIsFalse(String id, String companyUuid);
 
-    Page<VehicleType> findByDeletedIsFalse(Pageable pageable);
+    Page<VehicleType> findByCompanyUuidAndDeletedIsFalse(String companyUuid, Pageable pageable);
+
+    List<VehicleType> findByIdInAndCompanyUuid(Collection<String> ids, String companyUuid);
 }

--- a/src/main/java/com/easyreach/backend/security/CompanyContext.java
+++ b/src/main/java/com/easyreach/backend/security/CompanyContext.java
@@ -1,0 +1,28 @@
+package com.easyreach.backend.security;
+
+public final class CompanyContext {
+    private static final ThreadLocal<String> CURRENT_COMPANY = new ThreadLocal<>();
+
+    private CompanyContext() {}
+
+    public static void setCompanyId(String companyId) {
+        CURRENT_COMPANY.set(companyId);
+    }
+
+    public static String getCompanyId() {
+        return CURRENT_COMPANY.get();
+    }
+
+    public static String getRequiredCompanyId() {
+        String companyId = CURRENT_COMPANY.get();
+        if (companyId == null) {
+            throw new IllegalStateException("Company ID is not set in context");
+        }
+        return companyId;
+    }
+
+    public static void clear() {
+        CURRENT_COMPANY.remove();
+    }
+}
+

--- a/src/main/java/com/easyreach/backend/security/CompanyInterceptor.java
+++ b/src/main/java/com/easyreach/backend/security/CompanyInterceptor.java
@@ -1,0 +1,31 @@
+package com.easyreach.backend.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+public class CompanyInterceptor implements HandlerInterceptor {
+    private static final String HEADER = "X-Company-Id";
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        String companyId = request.getHeader(HEADER);
+        if (companyId == null || companyId.isBlank()) {
+            response.sendError(HttpStatus.BAD_REQUEST.value(), HEADER + " header is required");
+            return false;
+        }
+        CompanyContext.setCompanyId(companyId);
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        CompanyContext.clear();
+    }
+}
+


### PR DESCRIPTION
## Summary
- require `X-Company-Id` header on all API requests except auth and docs and expose company id via thread-local context
- scope vehicle type operations to current company
- centralize required company id retrieval and validate company-specific sync operations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ef7c1e0832dba8949599d4b8ea6