### PR TITLE
Handle missing company ID in JWT filter

### DIFF
--- a/src/main/java/com/easyreach/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/easyreach/backend/security/JwtAuthenticationFilter.java
@@ -42,6 +42,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                             userDetails, null, userDetails.getAuthorities());
                     SecurityContextHolder.getContext().setAuthentication(auth);
                     String companyId = jwtService.extractCompanyId(token);
+                    if (companyId == null || companyId.isBlank()) {
+                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Missing company ID");
+                        return;
+                    }
                     CompanyContext.setCompanyId(companyId);
                 }
             }

--- a/src/test/java/com/easyreach/backend/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/easyreach/backend/security/JwtAuthenticationFilterTest.java
@@ -56,6 +56,7 @@ class JwtAuthenticationFilterTest {
         when(jwtService.extractUsername("token")).thenReturn("user");
         when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
         when(jwtService.isTokenValid("token", userDetails)).thenReturn(true);
+        when(jwtService.extractCompanyId("token")).thenReturn("company1");
 
         filter.doFilterInternal(request, response, chain);
 
@@ -71,6 +72,25 @@ class JwtAuthenticationFilterTest {
         FilterChain chain = mock(FilterChain.class);
 
         when(jwtService.extractUsername("bad")).thenThrow(new RuntimeException("invalid"));
+
+        filter.doFilterInternal(request, response, chain);
+
+        verify(chain, never()).doFilter(request, response);
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    void missingCompanyId_returnsUnauthorized() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+        UserDetails userDetails = mock(UserDetails.class);
+
+        when(jwtService.extractUsername("token")).thenReturn("user");
+        when(userDetailsService.loadUserByUsername("user")).thenReturn(userDetails);
+        when(jwtService.isTokenValid("token", userDetails)).thenReturn(true);
+        when(jwtService.extractCompanyId("token")).thenReturn(null);
 
         filter.doFilterInternal(request, response, chain);
 


### PR DESCRIPTION
## Summary
- Reject requests missing `companyId` claim with 401 in `JwtAuthenticationFilter`
- Add unit test for missing company ID and update existing valid token test

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b474ec2a58832d8897d9125c29c907