### PR TITLE
Use non-empty JsonInclude for ApiResponse errors

### DIFF
--- a/src/main/java/com/easyreach/backend/dto/ApiResponse.java
+++ b/src/main/java/com/easyreach/backend/dto/ApiResponse.java
@@ -1,5 +1,7 @@
 package com.easyreach.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,8 @@ import java.util.List;
 public class ApiResponse<T> {
     private boolean success;
     private T data;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Schema(example = "[]")
     private List<String> errors = new ArrayList<>();
 
     public static <T> ApiResponse<T> success(T data) {


### PR DESCRIPTION
## Summary
- Omit `errors` from `ApiResponse` when the list is empty
- Provide Swagger example showing an empty errors array

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable parent POM)*
- `DB_URL=jdbc:h2:mem:testdb DB_USERNAME=sa DB_PASSWORD= JWT_SECRET=dummy SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.h2.Driver SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.H2Dialect SPRING_FLYWAY_ENABLED=false mvn -q spring-boot:run` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b4888b3edc832d84109138f3a528c8