### PR TITLE
feat: add nullable sync response counts

### DIFF
--- a/src/main/java/com/easyreach/backend/controller/SyncController.java
+++ b/src/main/java/com/easyreach/backend/controller/SyncController.java
@@ -36,34 +36,34 @@ public class SyncController {
     @Operation(summary = "Bulk synchronize entities", description = "Accepts lists of entity DTOs and persists them with isSynced=true")
     public ResponseEntity<ApiResponse<SyncResponseDto>> sync(@Valid @RequestBody SyncRequestDto request) {
         SyncResponseDto response = new SyncResponseDto();
-        if (request.getCompanies() != null && !request.getCompanies().isEmpty()) {
+        if (request.getCompanies() != null) {
             response.setCompanies(companyService.bulkSync(request.getCompanies()));
         }
-        if (request.getDailyExpenses() != null && !request.getDailyExpenses().isEmpty()) {
+        if (request.getDailyExpenses() != null) {
             response.setDailyExpenses(dailyExpenseService.bulkSync(request.getDailyExpenses()));
         }
-        if (request.getDieselUsages() != null && !request.getDieselUsages().isEmpty()) {
+        if (request.getDieselUsages() != null) {
             response.setDieselUsages(dieselUsageService.bulkSync(request.getDieselUsages()));
         }
-        if (request.getEquipmentUsages() != null && !request.getEquipmentUsages().isEmpty()) {
+        if (request.getEquipmentUsages() != null) {
             response.setEquipmentUsages(equipmentUsageService.bulkSync(request.getEquipmentUsages()));
         }
-        if (request.getExpenseMasters() != null && !request.getExpenseMasters().isEmpty()) {
+        if (request.getExpenseMasters() != null) {
             response.setExpenseMasters(expenseMasterService.bulkSync(request.getExpenseMasters()));
         }
-        if (request.getInternalVehicles() != null && !request.getInternalVehicles().isEmpty()) {
+        if (request.getInternalVehicles() != null) {
             response.setInternalVehicles(internalVehicleService.bulkSync(request.getInternalVehicles()));
         }
-        if (request.getPayers() != null && !request.getPayers().isEmpty()) {
+        if (request.getPayers() != null) {
             response.setPayers(payerService.bulkSync(request.getPayers()));
         }
-        if (request.getPayerSettlements() != null && !request.getPayerSettlements().isEmpty()) {
+        if (request.getPayerSettlements() != null) {
             response.setPayerSettlements(payerSettlementService.bulkSync(request.getPayerSettlements()));
         }
-        if (request.getVehicleEntries() != null && !request.getVehicleEntries().isEmpty()) {
+        if (request.getVehicleEntries() != null) {
             response.setVehicleEntries(vehicleEntryService.bulkSync(request.getVehicleEntries()));
         }
-        if (request.getVehicleTypes() != null && !request.getVehicleTypes().isEmpty()) {
+        if (request.getVehicleTypes() != null) {
             response.setVehicleTypes(vehicleTypeService.bulkSync(request.getVehicleTypes()));
         }
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/easyreach/backend/dto/SyncResponseDto.java
+++ b/src/main/java/com/easyreach/backend/dto/SyncResponseDto.java
@@ -1,5 +1,6 @@
 package com.easyreach.backend.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,16 +8,17 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SyncResponseDto {
-    private int companies;
-    private int dailyExpenses;
-    private int dieselUsages;
-    private int equipmentUsages;
-    private int expenseMasters;
-    private int internalVehicles;
-    private int payers;
-    private int payerSettlements;
-    private int vehicleEntries;
-    private int vehicleTypes;
+    private Integer companies;
+    private Integer dailyExpenses;
+    private Integer dieselUsages;
+    private Integer equipmentUsages;
+    private Integer expenseMasters;
+    private Integer internalVehicles;
+    private Integer payers;
+    private Integer payerSettlements;
+    private Integer vehicleEntries;
+    private Integer vehicleTypes;
 }
 

--- a/src/test/java/com/easyreach/backend/controller/SyncControllerTest.java
+++ b/src/test/java/com/easyreach/backend/controller/SyncControllerTest.java
@@ -1,0 +1,113 @@
+package com.easyreach.backend.controller;
+
+import com.easyreach.backend.dto.ApiResponse;
+import com.easyreach.backend.dto.SyncRequestDto;
+import com.easyreach.backend.dto.SyncResponseDto;
+import com.easyreach.backend.dto.companies.CompanyRequestDto;
+import com.easyreach.backend.dto.payers.PayerRequestDto;
+import com.easyreach.backend.service.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SyncControllerTest {
+
+    @Mock private CompanyService companyService;
+    @Mock private DailyExpenseService dailyExpenseService;
+    @Mock private DieselUsageService dieselUsageService;
+    @Mock private EquipmentUsageService equipmentUsageService;
+    @Mock private ExpenseMasterService expenseMasterService;
+    @Mock private InternalVehicleService internalVehicleService;
+    @Mock private PayerService payerService;
+    @Mock private PayerSettlementService payerSettlementService;
+    @Mock private VehicleEntryService vehicleEntryService;
+    @Mock private VehicleTypeService vehicleTypeService;
+    @Mock private SyncDownloadService syncDownloadService;
+
+    private SyncController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new SyncController(
+                companyService,
+                dailyExpenseService,
+                dieselUsageService,
+                equipmentUsageService,
+                expenseMasterService,
+                internalVehicleService,
+                payerService,
+                payerSettlementService,
+                vehicleEntryService,
+                vehicleTypeService,
+                syncDownloadService);
+    }
+
+    @Test
+    void sync_returns_null_counts_when_lists_absent() {
+        SyncRequestDto request = new SyncRequestDto();
+
+        ResponseEntity<ApiResponse<SyncResponseDto>> entity = controller.sync(request);
+        SyncResponseDto response = entity.getBody().getData();
+
+        assertNull(response.getCompanies());
+        assertNull(response.getDailyExpenses());
+        assertNull(response.getDieselUsages());
+        assertNull(response.getEquipmentUsages());
+        assertNull(response.getExpenseMasters());
+        assertNull(response.getInternalVehicles());
+        assertNull(response.getPayers());
+        assertNull(response.getPayerSettlements());
+        assertNull(response.getVehicleEntries());
+        assertNull(response.getVehicleTypes());
+
+        verifyNoInteractions(
+                companyService,
+                dailyExpenseService,
+                dieselUsageService,
+                equipmentUsageService,
+                expenseMasterService,
+                internalVehicleService,
+                payerService,
+                payerSettlementService,
+                vehicleEntryService,
+                vehicleTypeService);
+    }
+
+    @Test
+    void sync_sets_counts_for_processed_lists() {
+        SyncRequestDto request = new SyncRequestDto();
+        request.setCompanies(List.of(new CompanyRequestDto()));
+        request.setPayers(List.of(new PayerRequestDto()));
+        request.setVehicleEntries(Collections.emptyList());
+
+        when(companyService.bulkSync(any())).thenReturn(2);
+        when(payerService.bulkSync(any())).thenReturn(1);
+        when(vehicleEntryService.bulkSync(any())).thenReturn(0);
+
+        ResponseEntity<ApiResponse<SyncResponseDto>> entity = controller.sync(request);
+        SyncResponseDto response = entity.getBody().getData();
+
+        assertEquals(2, response.getCompanies());
+        assertEquals(1, response.getPayers());
+        assertEquals(0, response.getVehicleEntries());
+
+        assertNull(response.getDailyExpenses());
+        assertNull(response.getDieselUsages());
+        assertNull(response.getEquipmentUsages());
+        assertNull(response.getExpenseMasters());
+        assertNull(response.getInternalVehicles());
+        assertNull(response.getPayerSettlements());
+        assertNull(response.getVehicleTypes());
+    }
+}
+


### PR DESCRIPTION
## Summary
- use `Integer` counts in `SyncResponseDto` and ignore nulls in JSON
- populate sync counts only when lists are provided
- add tests for sync response counts

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4888115ac832dbbb328feefedc8d9