### PR TITLE
Add whitelist bypass to JWT filter

### DIFF
--- a/src/main/java/com/easyreach/backend/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/easyreach/backend/security/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -23,6 +24,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService; // will be CustomUserDetailsService
+    private final SecurityWhitelist securityWhitelist;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return securityWhitelist.getPaths().stream().anyMatch(pattern -> pathMatcher.match(pattern, path));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)

--- a/src/main/java/com/easyreach/backend/security/SecurityConfig.java
+++ b/src/main/java/com/easyreach/backend/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final UserDetailsService userDetailsService; // injected CustomUserDetailsService
+    private final SecurityWhitelist securityWhitelist;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -36,14 +37,7 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/login",
-                                "/auth/**",
-                                "/api/auth/**",
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html"
-                        ).permitAll()
+                        .requestMatchers(securityWhitelist.getPaths().toArray(String[]::new)).permitAll()
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/src/main/java/com/easyreach/backend/security/SecurityWhitelist.java
+++ b/src/main/java/com/easyreach/backend/security/SecurityWhitelist.java
@@ -1,0 +1,24 @@
+package com.easyreach.backend.security;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Defines URL patterns that should bypass JWT authentication.
+ */
+@Component
+public class SecurityWhitelist {
+    private final List<String> paths = List.of(
+            "/login",
+            "/auth/**",
+            "/api/auth/**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    );
+
+    public List<String> getPaths() {
+        return paths;
+    }
+}

--- a/src/test/java/com/easyreach/backend/security/SecurityConfigTest.java
+++ b/src/test/java/com/easyreach/backend/security/SecurityConfigTest.java
@@ -17,11 +17,13 @@ class SecurityConfigTest {
     private JwtAuthenticationFilter filter;
     @Mock
     private UserDetailsService userDetailsService;
+    @Mock
+    private SecurityWhitelist securityWhitelist;
 
 
     @Test
     void authenticationProvider_usesInjectedService() throws Exception {
-        SecurityConfig config = new SecurityConfig(filter, userDetailsService);
+        SecurityConfig config = new SecurityConfig(filter, userDetailsService, securityWhitelist);
         DaoAuthenticationProvider provider = (DaoAuthenticationProvider) config.authenticationProvider();
 
         Field field = DaoAuthenticationProvider.class.getDeclaredField("userDetailsService");


### PR DESCRIPTION
## Summary
- Centralize public URL patterns in `SecurityWhitelist`
- Skip JWT processing for whitelisted paths via `shouldNotFilter`
- Reuse whitelist in `SecurityConfig` and extend tests accordingly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe8ff83cc832d9faf1af804502f58