### PR TITLE
chore(web): mark DTO imports as type-only

### DIFF
--- a/apps/web/src/api/hooks.ts
+++ b/apps/web/src/api/hooks.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from './axios'
-import { Page, PagingParams } from '@easyreach/types'
+import type { Page, PagingParams } from '@easyreach/types'
 
 export const useList = <T>(key: string, url: string, params?: PagingParams) =>
   useQuery({

--- a/apps/web/src/features/auth/pages/Login.tsx
+++ b/apps/web/src/features/auth/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { LoginRequest } from '@easyreach/types'
+import type { LoginRequest } from '@easyreach/types'
 import { useAuth } from '../../../providers/AuthProvider'
 import { Input, Button } from '@easyreach/ui'
 import { useNavigate } from 'react-router-dom'

--- a/apps/web/src/features/companies/api.ts
+++ b/apps/web/src/features/companies/api.ts
@@ -1,4 +1,4 @@
-import { CompanyRequestDto, CompanyResponseDto, PagingParams } from '@easyreach/types'
+import type { CompanyRequestDto, CompanyResponseDto, PagingParams } from '@easyreach/types'
 import { endpoints } from '../../api/endpoints'
 import { useList, useCreate } from '../../api/hooks'
 

--- a/apps/web/src/features/vehicle-entries-ops/api.ts
+++ b/apps/web/src/features/vehicle-entries-ops/api.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import api from '../../api/axios'
 import { endpoints } from '../../api/endpoints'
-import { VehicleEntryResponseDto } from '@easyreach/types'
+import type { VehicleEntryResponseDto } from '@easyreach/types'
 
 export interface PaymentRequest {
   amount: number

--- a/apps/web/src/providers/AuthProvider.tsx
+++ b/apps/web/src/providers/AuthProvider.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState, useEffect, ReactNode } from 'react'
-import { AuthResponse, LoginRequest, UserDto } from '@easyreach/types'
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+import type { AuthResponse, LoginRequest, UserDto } from '@easyreach/types'
 import api from '../api/axios'
 import { endpoints } from '../api/endpoints'
 

--- a/apps/web/src/test/__mocks__/msw.ts
+++ b/apps/web/src/test/__mocks__/msw.ts
@@ -1,6 +1,6 @@
 import { setupServer } from 'msw/node'
 import { http, HttpResponse } from 'msw'
-import {
+import type {
   AuthResponse,
   CompanyResponseDto,
   Page,


### PR DESCRIPTION
## Summary
- refactor various web modules to use type-only imports for DTOs and React types

## Testing
- `pnpm --filter web build`
- `pnpm test:web` *(fails: Failed to resolve import "msw/node" from "src/test/__mocks__/msw.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68bc20640388832d89f64177ecf76b2e