### PR TITLE
Configure VITE_API_BASE_URL for web app

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8080

--- a/apps/web/src/api/axios.ts
+++ b/apps/web/src/api/axios.ts
@@ -4,6 +4,8 @@ const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
 })
 
+console.log('API baseURL:', api.defaults.baseURL)
+
 let isRefreshing = false
 let subscribers: ((token: string) => void)[] = []
 


### PR DESCRIPTION
## Summary
- add local VITE_API_BASE_URL env
- log axios base URL for debugging

## Testing
- `pnpm test:web` *(fails: Failed to resolve import "msw/node")*
- `timeout 5 pnpm dev:web`
- `curl -s http://localhost:5173/src/api/axios.ts | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68bc2353f454832d888a0b30022c6e49