### PR TITLE
feat: add rest-assured API tests

### DIFF
--- a/api-tests/src/test/java/com/easyreach/tests/auth/AuthClient.java
+++ b/api-tests/src/test/java/com/easyreach/tests/auth/AuthClient.java
@@ -3,36 +3,34 @@ package com.easyreach.tests.auth;
 import com.easyreach.tests.config.TestConfig;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public final class AuthClient {
-    private static String token;
+public class AuthClient {
+    private static String accessToken;
 
-    private AuthClient() {
-    }
-
-    public static synchronized String getToken() {
-        if (token == null) {
-            Map<String, Object> body = new HashMap<>();
-            if (TestConfig.getAuthEmail() != null) {
-                body.put("email", TestConfig.getAuthEmail());
-            }
-            if (TestConfig.getAuthMobile() != null) {
-                body.put("mobile", TestConfig.getAuthMobile());
-            }
-            body.put("password", TestConfig.getAuthPassword());
-
-            token = RestAssured.given()
-                    .contentType(ContentType.JSON)
-                    .body(body)
-                    .post(TestConfig.getBaseUrl() + "/auth/login")
-                    .then()
-                    .statusCode(200)
-                    .extract()
-                    .path("accessToken");
+    public static synchronized String getAccessToken() {
+        if (accessToken != null) {
+            return accessToken;
         }
-        return token;
+        Map<String, Object> body = new HashMap<>();
+        String email = TestConfig.getAuthEmail();
+        String mobile = TestConfig.getAuthMobile();
+        String password = TestConfig.getAuthPassword();
+        if (email != null && !email.isEmpty()) {
+            body.put("email", email);
+        } else if (mobile != null && !mobile.isEmpty()) {
+            body.put("mobileNo", mobile);
+        }
+        body.put("password", password);
+        Response response = RestAssured.given()
+                .baseUri(TestConfig.getBaseUrl())
+                .contentType(ContentType.JSON)
+                .body(body)
+                .post("/auth/login");
+        accessToken = response.jsonPath().getString("accessToken");
+        return accessToken;
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/auth/AuthClientTest.java
+++ b/api-tests/src/test/java/com/easyreach/tests/auth/AuthClientTest.java
@@ -1,14 +1,23 @@
 package com.easyreach.tests.auth;
 
+import com.easyreach.tests.config.TestConfig;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
 
-class AuthClientTest {
-
+@Tag("e2e")
+public class AuthClientTest {
     @Test
-    void login() {
-        String token = AuthClient.getToken();
-        assertNotNull(token);
+    void loginAndRefresh() {
+        String email = TestConfig.getAuthEmail();
+        String password = TestConfig.getAuthPassword();
+        given().baseUri(TestConfig.getBaseUrl())
+                .contentType(ContentType.JSON)
+                .body("{\"email\":\"" + email + "\",\"password\":\"" + password + "\"}")
+                .post("/auth/login")
+                .then().statusCode(200).body("accessToken", notNullValue());
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/companies/CompanyIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/companies/CompanyIT.java
@@ -3,74 +3,68 @@ package com.easyreach.tests.companies;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
-import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 
-@TestMethodOrder(OrderAnnotation.class)
 @Tag("e2e")
-class CompanyIT extends BaseIT {
+@TestMethodOrder(OrderAnnotation.class)
+public class CompanyIT extends BaseIT {
+    private static String companyId;
 
     @Test
     @Order(1)
-    void createCompany() throws Exception {
-        String json = givenAuth()
-                .body(SampleData.company())
-                .post("/companies")
-                .then()
-                .statusCode(201)
-                .extract().asString();
-        JsonNode node = MAPPER.readTree(json);
-        String id = node.get("id").asText();
-        IdStore.put("company", id);
-        assertThat(node.get("name").asText(), equalTo(node.get("name").asText()));
+    void shouldCreateCompany() {
+        Map<String, Object> body = SampleData.companyRequest();
+        Response r = given().spec(spec).body(body).post("/api/companies");
+        r.then().statusCode(200);
+        companyId = r.jsonPath().getString("data.uuid");
+        assertThat(companyId, notNullValue());
+        IdStore.put("companyUuid", companyId);
     }
 
     @Test
     @Order(2)
-    void getCompany() {
-        String id = IdStore.get("company");
-        givenAuth()
-                .get("/companies/{id}", id)
-                .then()
-                .statusCode(200)
-                .body("id", equalTo(id));
+    void shouldGetCompany() {
+        String id = IdStore.get("companyUuid");
+        Response r = given().spec(spec).get("/api/companies/" + id);
+        r.then().statusCode(200).body("data.uuid", equalTo(id));
     }
 
     @Test
     @Order(3)
-    void listCompanies() {
-        givenAuth()
-                .queryParams(pageable())
-                .get("/companies")
-                .then()
-                .statusCode(200);
+    void shouldListCompanies() {
+        given().spec(spec).get("/api/companies" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
     }
 
     @Test
     @Order(4)
-    void updateCompany() {
-        String id = IdStore.get("company");
-        givenAuth()
-                .body(SampleData.company())
-                .put("/companies/{id}", id)
-                .then()
-                .statusCode(200);
+    void shouldUpdateCompany() {
+        String id = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.companyRequest();
+        body.put("uuid", id);
+        body.put("companyName", "Updated Co");
+        given().spec(spec).body(body).put("/api/companies/" + id)
+                .then().statusCode(200)
+                .body("data.companyName", equalTo("Updated Co"));
     }
 
     @Test
     @Order(5)
-    void deleteCompany() {
-        String id = IdStore.get("company");
-        givenAuth()
-                .delete("/companies/{id}", id)
-                .then()
-                .statusCode(204);
+    void shouldDeleteCompany() {
+        String id = IdStore.get("companyUuid");
+        given().spec(spec).delete("/api/companies/" + id)
+                .then().statusCode(200);
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/config/TestConfig.java
+++ b/api-tests/src/test/java/com/easyreach/tests/config/TestConfig.java
@@ -1,35 +1,21 @@
 package com.easyreach.tests.config;
 
-public final class TestConfig {
-    private TestConfig() {
-    }
-
-    private static String get(String key) {
-        String value = System.getProperty(key);
-        if (value == null) {
-            value = System.getenv(key);
-        }
-        return value;
-    }
-
-    private static String get(String key, String def) {
-        String value = get(key);
-        return value == null ? def : value;
-    }
+public class TestConfig {
+    private static final String BASE_URL_DEFAULT = "http://localhost:8080";
 
     public static String getBaseUrl() {
-        return get("BASE_URL", "http://localhost:8080");
+        return System.getProperty("BASE_URL", System.getenv().getOrDefault("BASE_URL", BASE_URL_DEFAULT));
     }
 
     public static String getAuthEmail() {
-        return get("AUTH_EMAIL");
+        return System.getProperty("AUTH_EMAIL", System.getenv().get("AUTH_EMAIL"));
     }
 
     public static String getAuthMobile() {
-        return get("AUTH_MOBILE");
+        return System.getProperty("AUTH_MOBILE", System.getenv().get("AUTH_MOBILE"));
     }
 
     public static String getAuthPassword() {
-        return get("AUTH_PASSWORD", "admin");
+        return System.getProperty("AUTH_PASSWORD", System.getenv().getOrDefault("AUTH_PASSWORD", ""));
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/core/BaseIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/core/BaseIT.java
@@ -2,38 +2,28 @@ package com.easyreach.tests.core;
 
 import com.easyreach.tests.auth.AuthClient;
 import com.easyreach.tests.config.TestConfig;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.restassured.RestAssured;
-import io.restassured.config.ObjectMapperConfig;
+import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.ContentType;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeAll;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public abstract class BaseIT {
-    public static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+    protected static RequestSpecification spec;
 
     @BeforeAll
-    public static void setupRestAssured() {
-        RestAssured.baseURI = TestConfig.getBaseUrl();
-        RestAssured.config = RestAssured.config().objectMapperConfig(new ObjectMapperConfig(ObjectMapperType.JACKSON_2));
+    static void initSpec() {
+        spec = new RequestSpecBuilder()
+                .setBaseUri(TestConfig.getBaseUrl())
+                .setContentType(ContentType.JSON)
+                .addHeader("Authorization", "Bearer " + AuthClient.getAccessToken())
+                .build();
     }
 
-    protected RequestSpecification givenAuth() {
-        return RestAssured.given()
-                .contentType(ContentType.JSON)
-                .accept(ContentType.JSON)
-                .header("Authorization", "Bearer " + AuthClient.getToken());
+    protected String pageable() {
+        return "?page=0&size=10";
     }
 
-    protected Map<String, Object> pageable() {
-        Map<String, Object> params = new HashMap<>();
-        params.put("page", 0);
-        params.put("size", 20);
-        return params;
+    protected String pageable(String sort) {
+        return pageable() + "&sort=" + sort;
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/core/IdStore.java
+++ b/api-tests/src/test/java/com/easyreach/tests/core/IdStore.java
@@ -1,19 +1,16 @@
 package com.easyreach.tests.core;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
-public final class IdStore {
-    private static final ConcurrentMap<String, String> IDS = new ConcurrentHashMap<>();
+public class IdStore {
+    private static final Map<String, String> STORE = new ConcurrentHashMap<>();
 
-    private IdStore() {
-    }
-
-    public static void put(String key, String id) {
-        IDS.put(key, id);
+    public static void put(String key, String value) {
+        STORE.put(key, value);
     }
 
     public static String get(String key) {
-        return IDS.get(key);
+        return STORE.get(key);
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/core/SampleData.java
+++ b/api-tests/src/test/java/com/easyreach/tests/core/SampleData.java
@@ -2,91 +2,220 @@ package com.easyreach.tests.core;
 
 import net.datafaker.Faker;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
-public final class SampleData {
+public class SampleData {
     private static final Faker FAKER = new Faker();
 
-    private SampleData() {
-    }
-
-    public static Map<String, Object> company() {
+    public static Map<String, Object> companyRequest() {
         Map<String, Object> m = new HashMap<>();
-        m.put("name", FAKER.company().name());
-        m.put("address", FAKER.address().fullAddress());
+        m.put("uuid", UUID.randomUUID().toString());
+        m.put("companyCode", FAKER.number().digits(5));
+        m.put("companyName", FAKER.company().name());
+        m.put("companyContactNo", FAKER.phoneNumber().subscriberNumber(10));
+        m.put("companyLocation", FAKER.address().city());
+        m.put("companyRegistrationDate", LocalDate.now().toString());
+        m.put("ownerName", FAKER.name().fullName());
+        m.put("ownerMobileNo", FAKER.phoneNumber().subscriberNumber(10));
+        m.put("ownerEmailAddress", FAKER.internet().emailAddress());
+        m.put("ownerDob", LocalDate.now().minusYears(30).toString());
+        m.put("isActive", true);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> vehicleType() {
+    public static Map<String, Object> vehicleTypeRequest(String companyUuid) {
         Map<String, Object> m = new HashMap<>();
-        m.put("name", FAKER.rockBand().name());
+        m.put("id", UUID.randomUUID().toString());
+        m.put("vehicleType", FAKER.ancient().god());
+        m.put("type", "GENERAL");
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> internalVehicle() {
+    public static Map<String, Object> internalVehicleRequest(String companyUuid) {
         Map<String, Object> m = new HashMap<>();
-        m.put("vehicleNumber", "V-" + FAKER.number().digits(5));
-        m.put("type", vehicleType());
+        m.put("vehicleId", UUID.randomUUID().toString());
+        m.put("vehicleName", FAKER.vehicle().model());
+        m.put("vehicleType", "TRUCK");
+        m.put("isActive", true);
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> vehicleEntry() {
+    public static Map<String, Object> vehicleEntryRequest(String companyUuid, String payerId, String vehicleType) {
         Map<String, Object> m = new HashMap<>();
-        m.put("vehicleNumber", "E-" + FAKER.number().digits(5));
-        m.put("enteredAt", Instant.now().toString());
+        m.put("entryId", UUID.randomUUID().toString());
+        m.put("companyUuid", companyUuid);
+        m.put("payerId", payerId);
+        m.put("vehicleNumber", "MH" + FAKER.number().digits(8));
+        m.put("vehicleType", vehicleType);
+        m.put("fromAddress", FAKER.address().streetAddress());
+        m.put("toAddress", FAKER.address().streetAddress());
+        m.put("driverName", FAKER.name().fullName());
+        m.put("driverContactNo", FAKER.phoneNumber().subscriberNumber(10));
+        m.put("commission", BigDecimal.valueOf(10));
+        m.put("beta", BigDecimal.valueOf(5));
+        m.put("amount", BigDecimal.valueOf(1000));
+        m.put("paytype", "CASH");
+        m.put("entryDate", LocalDate.now().toString());
+        m.put("entryTime", Instant.now().toString());
+        m.put("paidAmount", BigDecimal.ZERO);
+        m.put("pendingAmt", BigDecimal.valueOf(1000));
+        m.put("isSettled", false);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> dailyExpense() {
+    public static Map<String, Object> dailyExpenseRequest(String companyUuid) {
         Map<String, Object> m = new HashMap<>();
-        m.put("expenseDate", LocalDate.now().toString());
-        m.put("amount", FAKER.number().randomDouble(2, 10, 100));
-        m.put("description", FAKER.lorem().sentence());
+        m.put("expenseId", UUID.randomUUID().toString());
+        m.put("expenseType", "FUEL");
+        m.put("expenseAmount", BigDecimal.valueOf(100));
+        m.put("expenseDate", Instant.now().toString());
+        m.put("isPaid", true);
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> expenseMaster() {
+    public static Map<String, Object> dieselUsageRequest(String companyUuid, String vehicleName) {
         Map<String, Object> m = new HashMap<>();
-        m.put("name", FAKER.commerce().productName());
+        m.put("dieselUsageId", UUID.randomUUID().toString());
+        m.put("vehicleName", vehicleName);
+        m.put("date", Instant.now().toString());
+        m.put("liters", BigDecimal.valueOf(50));
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> dieselUsage() {
+    public static Map<String, Object> equipmentUsageRequest(String companyUuid) {
         Map<String, Object> m = new HashMap<>();
-        m.put("quantity", FAKER.number().numberBetween(1, 100));
-        m.put("usedAt", Instant.now().toString());
+        m.put("equipmentUsageId", UUID.randomUUID().toString());
+        m.put("equipmentName", FAKER.job().field());
+        m.put("equipmentType", "GENERIC");
+        m.put("startKm", BigDecimal.valueOf(0));
+        m.put("endKm", BigDecimal.valueOf(10));
+        m.put("startTime", Instant.now().toString());
+        m.put("endTime", Instant.now().toString());
+        m.put("date", Instant.now().toString());
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> equipmentUsage() {
+    public static Map<String, Object> expenseMasterRequest(String companyUuid) {
         Map<String, Object> m = new HashMap<>();
-        m.put("equipment", FAKER.commerce().material());
-        m.put("usedAt", Instant.now().toString());
+        m.put("id", UUID.randomUUID().toString());
+        m.put("expenseName", FAKER.commerce().productName());
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
         return m;
     }
 
-    public static Map<String, Object> payer() {
+    public static Map<String, Object> payerRequest(String companyUuid) {
         Map<String, Object> m = new HashMap<>();
+        m.put("payerId", UUID.randomUUID().toString());
+        m.put("payerName", FAKER.name().fullName());
+        m.put("mobileNo", FAKER.phoneNumber().subscriberNumber(10));
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
+        return m;
+    }
+
+    public static Map<String, Object> payerSettlementRequest(String companyUuid, String payerId) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("settlementId", UUID.randomUUID().toString());
+        m.put("payerId", payerId);
+        m.put("amount", BigDecimal.valueOf(100));
+        m.put("date", Instant.now().toString());
+        m.put("companyUuid", companyUuid);
+        m.put("isSynced", true);
+        m.put("createdAt", Instant.now().toString());
+        m.put("updatedAt", Instant.now().toString());
+        m.put("deleted", false);
+        return m;
+    }
+
+    public static Map<String, Object> refreshTokenRequest(String userId) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("jti", UUID.randomUUID().toString());
+        m.put("userId", userId);
+        m.put("issuedAt", Instant.now().toString());
+        m.put("expiresAt", Instant.now().plusSeconds(3600).toString());
+        return m;
+    }
+
+    public static Map<String, Object> userRequest(String companyUuid) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("id", UUID.randomUUID().toString());
+        m.put("employeeId", FAKER.idNumber().valid());
+        m.put("email", FAKER.internet().emailAddress());
+        m.put("mobileNo", FAKER.phoneNumber().subscriberNumber(10));
+        m.put("password", "password");
+        m.put("role", "USER");
         m.put("name", FAKER.name().fullName());
+        m.put("companyUuid", companyUuid);
+        m.put("companyCode", FAKER.number().digits(5));
+        m.put("isActive", true);
         return m;
     }
 
-    public static Map<String, Object> payerSettlement() {
+    public static Map<String, Object> addPaymentRequest() {
         Map<String, Object> m = new HashMap<>();
-        m.put("settledAt", Instant.now().toString());
-        m.put("amount", FAKER.number().randomDouble(2, 10, 100));
+        m.put("amount", BigDecimal.valueOf(100));
+        m.put("receivedBy", FAKER.name().fullName());
+        m.put("when", Instant.now().toString());
         return m;
     }
 
-    public static Map<String, Object> ledgerPayment() {
+    public static Map<String, Object> applyPaymentRequest() {
         Map<String, Object> m = new HashMap<>();
-        m.put("paymentDate", LocalDate.now().toString());
-        m.put("amount", FAKER.number().randomDouble(2, 10, 100));
-        m.put("reference", UUID.randomUUID().toString());
+        m.put("amount", BigDecimal.valueOf(100));
+        m.put("settlementType", "CASH");
+        return m;
+    }
+
+    public static Map<String, Object> syncRequest(Map<String, Object> company, Map<String, Object> payer,
+                                                 Map<String, Object> vehicleType, Map<String, Object> vehicleEntry) {
+        Map<String, Object> m = new HashMap<>();
+        m.put("companies", Collections.singletonList(company));
+        m.put("payers", Collections.singletonList(payer));
+        m.put("vehicleTypes", Collections.singletonList(vehicleType));
+        m.put("vehicleEntries", Collections.singletonList(vehicleEntry));
         return m;
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/entries/VehicleEntryIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/entries/VehicleEntryIT.java
@@ -1,0 +1,93 @@
+package com.easyreach.tests.entries;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class VehicleEntryIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateVehicleEntry() {
+        String companyId = ensureCompany();
+        String payerId = ensurePayer();
+        Map<String, Object> body = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
+        Response r = given().spec(spec).body(body).post("/api/vehicle-entries");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.entryId");
+        IdStore.put("entryId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetVehicleEntry() {
+        String id = IdStore.get("entryId");
+        given().spec(spec).get("/api/vehicle-entries/" + id)
+                .then().statusCode(200).body("data.entryId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListVehicleEntries() {
+        given().spec(spec).get("/api/vehicle-entries" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateVehicleEntry() {
+        String id = IdStore.get("entryId");
+        String companyId = IdStore.get("companyUuid");
+        String payerId = IdStore.get("payerId");
+        Map<String, Object> body = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
+        body.put("entryId", id);
+        body.put("amount", 1500);
+        given().spec(spec).body(body).put("/api/vehicle-entries/" + id)
+                .then().statusCode(200)
+                .body("data.amount", equalTo(1500));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteVehicleEntry() {
+        String id = IdStore.get("entryId");
+        given().spec(spec).delete("/api/vehicle-entries/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+
+    private String ensurePayer() {
+        String id = IdStore.get("payerId");
+        if (id == null) {
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.payerRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/payers");
+            id = r.jsonPath().getString("data.payerId");
+            IdStore.put("payerId", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/equipment/EquipmentUsageIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/equipment/EquipmentUsageIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.equipment;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class EquipmentUsageIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateEquipmentUsage() {
+        String companyId = ensureCompany();
+        Map<String, Object> body = SampleData.equipmentUsageRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/equipment-usage");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.equipmentUsageId");
+        IdStore.put("equipmentUsageId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetEquipmentUsage() {
+        String id = IdStore.get("equipmentUsageId");
+        given().spec(spec).get("/api/equipment-usage/" + id)
+                .then().statusCode(200).body("data.equipmentUsageId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListEquipmentUsage() {
+        given().spec(spec).get("/api/equipment-usage" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateEquipmentUsage() {
+        String id = IdStore.get("equipmentUsageId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.equipmentUsageRequest(companyId);
+        body.put("equipmentUsageId", id);
+        body.put("endKm", 20);
+        given().spec(spec).body(body).put("/api/equipment-usage/" + id)
+                .then().statusCode(200)
+                .body("data.endKm", equalTo(20));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteEquipmentUsage() {
+        String id = IdStore.get("equipmentUsageId");
+        given().spec(spec).delete("/api/equipment-usage/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/expenses/DailyExpenseIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/expenses/DailyExpenseIT.java
@@ -1,0 +1,82 @@
+package com.easyreach.tests.expenses;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class DailyExpenseIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateDailyExpense() {
+        String companyId = ensureCompany();
+        Map<String, Object> body = SampleData.dailyExpenseRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/daily-expenses");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.expenseId");
+        IdStore.put("dailyExpenseId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetDailyExpense() {
+        String id = IdStore.get("dailyExpenseId");
+        given().spec(spec).get("/api/daily-expenses/" + id)
+                .then().statusCode(200).body("data.expenseId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListDailyExpenses() {
+        String from = Instant.now().minusSeconds(3600).toString();
+        String to = Instant.now().toString();
+        given().spec(spec).get("/api/daily-expenses" + pageable() + "&dateFrom=" + from + "&dateTo=" + to)
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateDailyExpense() {
+        String id = IdStore.get("dailyExpenseId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.dailyExpenseRequest(companyId);
+        body.put("expenseId", id);
+        body.put("expenseAmount", 200);
+        given().spec(spec).body(body).put("/api/daily-expenses/" + id)
+                .then().statusCode(200)
+                .body("data.expenseAmount", equalTo(200));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteDailyExpense() {
+        String id = IdStore.get("dailyExpenseId");
+        given().spec(spec).delete("/api/daily-expenses/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/expenses/ExpenseMasterIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/expenses/ExpenseMasterIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.expenses;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class ExpenseMasterIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateExpenseMaster() {
+        String companyId = ensureCompany();
+        Map<String, Object> body = SampleData.expenseMasterRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/expense-master");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.id");
+        IdStore.put("expenseMasterId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetExpenseMaster() {
+        String id = IdStore.get("expenseMasterId");
+        given().spec(spec).get("/api/expense-master/" + id)
+                .then().statusCode(200).body("data.id", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListExpenseMasters() {
+        given().spec(spec).get("/api/expense-master" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateExpenseMaster() {
+        String id = IdStore.get("expenseMasterId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.expenseMasterRequest(companyId);
+        body.put("id", id);
+        body.put("expenseName", "UpdatedExpense");
+        given().spec(spec).body(body).put("/api/expense-master/" + id)
+                .then().statusCode(200)
+                .body("data.expenseName", equalTo("UpdatedExpense"));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteExpenseMaster() {
+        String id = IdStore.get("expenseMasterId");
+        given().spec(spec).delete("/api/expense-master/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/fuel/DieselUsageIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/fuel/DieselUsageIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.fuel;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class DieselUsageIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateDieselUsage() {
+        String companyId = ensureCompany();
+        Map<String, Object> body = SampleData.dieselUsageRequest(companyId, "VehicleA");
+        Response r = given().spec(spec).body(body).post("/api/diesel-usage");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.dieselUsageId");
+        IdStore.put("dieselUsageId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetDieselUsage() {
+        String id = IdStore.get("dieselUsageId");
+        given().spec(spec).get("/api/diesel-usage/" + id)
+                .then().statusCode(200).body("data.dieselUsageId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListDieselUsage() {
+        given().spec(spec).get("/api/diesel-usage" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateDieselUsage() {
+        String id = IdStore.get("dieselUsageId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.dieselUsageRequest(companyId, "VehicleA");
+        body.put("dieselUsageId", id);
+        body.put("liters", 60);
+        given().spec(spec).body(body).put("/api/diesel-usage/" + id)
+                .then().statusCode(200)
+                .body("data.liters", equalTo(60));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteDieselUsage() {
+        String id = IdStore.get("dieselUsageId");
+        given().spec(spec).delete("/api/diesel-usage/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/ledger/LedgerIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/ledger/LedgerIT.java
@@ -1,0 +1,81 @@
+package com.easyreach.tests.ledger;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class LedgerIT extends BaseIT {
+    private void ensureLedgerData() {
+        if (IdStore.get("entryId") == null) {
+            String companyId = IdStore.get("companyUuid");
+            if (companyId == null) {
+                Map<String, Object> company = SampleData.companyRequest();
+                Response cr = given().spec(spec).body(company).post("/api/companies");
+                companyId = cr.jsonPath().getString("data.uuid");
+                IdStore.put("companyUuid", companyId);
+            }
+            String payerId = IdStore.get("payerId");
+            if (payerId == null) {
+                Map<String, Object> payer = SampleData.payerRequest(companyId);
+                Response pr = given().spec(spec).body(payer).post("/api/payers");
+                payerId = pr.jsonPath().getString("data.payerId");
+                IdStore.put("payerId", payerId);
+            }
+            Map<String, Object> entry = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
+            Response er = given().spec(spec).body(entry).post("/api/vehicle-entries");
+            String entryId = er.jsonPath().getString("data.entryId");
+            IdStore.put("entryId", entryId);
+        }
+    }
+
+    @Test
+    @Order(1)
+    void shouldGetAllLedgers() {
+        ensureLedgerData();
+        given().spec(spec).get("/api/ledger" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetLedgerForPayer() {
+        ensureLedgerData();
+        String payerId = IdStore.get("payerId");
+        given().spec(spec).get("/api/ledger/" + payerId + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(3)
+    void shouldGetLedgerSummary() {
+        ensureLedgerData();
+        given().spec(spec).get("/api/ledger/summary")
+                .then().statusCode(200)
+                .body("data", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldApplyPayment() {
+        ensureLedgerData();
+        String payerId = IdStore.get("payerId");
+        Map<String, Object> body = SampleData.applyPaymentRequest();
+        given().spec(spec).body(body).post("/api/ledger/" + payerId + "/apply-payment")
+                .then().statusCode(200);
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/ops/PayerOpsIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/ops/PayerOpsIT.java
@@ -1,0 +1,55 @@
+package com.easyreach.tests.ops;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class PayerOpsIT extends BaseIT {
+    private void ensurePayer() {
+        if (IdStore.get("payerId") == null) {
+            String companyId = IdStore.get("companyUuid");
+            if (companyId == null) {
+                Map<String, Object> company = SampleData.companyRequest();
+                Response cr = given().spec(spec).body(company).post("/api/companies");
+                companyId = cr.jsonPath().getString("data.uuid");
+                IdStore.put("companyUuid", companyId);
+            }
+            Map<String, Object> payer = SampleData.payerRequest(companyId);
+            Response pr = given().spec(spec).body(payer).post("/api/payers");
+            String payerId = pr.jsonPath().getString("data.payerId");
+            IdStore.put("payerId", payerId);
+        }
+    }
+
+    @Test
+    @Order(1)
+    void shouldSearchPayers() {
+        ensurePayer();
+        String companyId = IdStore.get("companyUuid");
+        given().spec(spec).get("/api/payers-ops/search?companyUuid=" + companyId + "&q=&page=0&size=10")
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(2)
+    void shouldSoftDeletePayer() {
+        ensurePayer();
+        String payerId = IdStore.get("payerId");
+        given().spec(spec).delete("/api/payers-ops/" + payerId + "/soft")
+                .then().statusCode(200);
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/ops/VehicleEntryOpsIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/ops/VehicleEntryOpsIT.java
@@ -1,0 +1,67 @@
+package com.easyreach.tests.ops;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class VehicleEntryOpsIT extends BaseIT {
+    private String ensureEntry() {
+        String id = IdStore.get("entryId");
+        if (id == null) {
+            // create dependencies
+            String companyId = IdStore.get("companyUuid");
+            if (companyId == null) {
+                Map<String, Object> company = SampleData.companyRequest();
+                Response cr = given().spec(spec).body(company).post("/api/companies");
+                companyId = cr.jsonPath().getString("data.uuid");
+                IdStore.put("companyUuid", companyId);
+            }
+            String payerId = IdStore.get("payerId");
+            if (payerId == null) {
+                Map<String, Object> payer = SampleData.payerRequest(companyId);
+                Response pr = given().spec(spec).body(payer).post("/api/payers");
+                payerId = pr.jsonPath().getString("data.payerId");
+                IdStore.put("payerId", payerId);
+            }
+            Map<String, Object> entry = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
+            Response er = given().spec(spec).body(entry).post("/api/vehicle-entries");
+            id = er.jsonPath().getString("data.entryId");
+            IdStore.put("entryId", id);
+        }
+        return id;
+    }
+
+    @Test
+    @Order(1)
+    void shouldAddPayment() {
+        String entryId = ensureEntry();
+        Map<String, Object> body = SampleData.addPaymentRequest();
+        given().spec(spec).body(body).post("/api/vehicle-entries-ops/" + entryId + "/payment")
+                .then().statusCode(200)
+                .body("data.entryId", equalTo(entryId));
+    }
+
+    @Test
+    @Order(2)
+    void shouldExitVehicle() {
+        String entryId = ensureEntry();
+        String when = Instant.now().toString();
+        given().spec(spec).post("/api/vehicle-entries-ops/" + entryId + "/exit?when=" + when)
+                .then().statusCode(200)
+                .body("data.entryId", equalTo(entryId));
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/payers/PayerIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/payers/PayerIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.payers;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class PayerIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreatePayer() {
+        String companyId = ensureCompany();
+        Map<String, Object> body = SampleData.payerRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/payers");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.payerId");
+        IdStore.put("payerId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetPayer() {
+        String id = IdStore.get("payerId");
+        given().spec(spec).get("/api/payers/" + id)
+                .then().statusCode(200).body("data.payerId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListPayers() {
+        given().spec(spec).get("/api/payers" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdatePayer() {
+        String id = IdStore.get("payerId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.payerRequest(companyId);
+        body.put("payerId", id);
+        body.put("payerName", "Updated Payer");
+        given().spec(spec).body(body).put("/api/payers/" + id)
+                .then().statusCode(200)
+                .body("data.payerName", equalTo("Updated Payer"));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeletePayer() {
+        String id = IdStore.get("payerId");
+        given().spec(spec).delete("/api/payers/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/payers/PayerSettlementIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/payers/PayerSettlementIT.java
@@ -1,0 +1,104 @@
+package com.easyreach.tests.payers;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class PayerSettlementIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreatePayerSettlement() {
+        String companyId = ensureCompany();
+        String payerId = ensurePayer();
+        Map<String, Object> body = SampleData.payerSettlementRequest(companyId, payerId);
+        Response r = given().spec(spec).body(body).post("/api/payer-settlements");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.settlementId");
+        IdStore.put("settlementId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetPayerSettlement() {
+        String id = IdStore.get("settlementId");
+        given().spec(spec).get("/api/payer-settlements/" + id)
+                .then().statusCode(200).body("data.settlementId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListPayerSettlements() {
+        given().spec(spec).get("/api/payer-settlements" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdatePayerSettlement() {
+        String id = IdStore.get("settlementId");
+        String companyId = IdStore.get("companyUuid");
+        String payerId = IdStore.get("payerId");
+        Map<String, Object> body = SampleData.payerSettlementRequest(companyId, payerId);
+        body.put("settlementId", id);
+        body.put("amount", 200);
+        given().spec(spec).body(body).put("/api/payer-settlements/" + id)
+                .then().statusCode(200)
+                .body("data.amount", equalTo(200));
+    }
+
+    @Test
+    @Order(5)
+    void shouldGetByPayerAndCompany() {
+        String payerId = IdStore.get("payerId");
+        String companyId = IdStore.get("companyUuid");
+        given().spec(spec).get("/api/payer-settlements/payer/" + payerId)
+                .then().statusCode(200).body("data", notNullValue());
+        given().spec(spec).get("/api/payer-settlements/company/" + companyId)
+                .then().statusCode(200).body("data", notNullValue());
+    }
+
+    @Test
+    @Order(6)
+    void shouldDeletePayerSettlement() {
+        String id = IdStore.get("settlementId");
+        given().spec(spec).delete("/api/payer-settlements/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+
+    private String ensurePayer() {
+        String id = IdStore.get("payerId");
+        if (id == null) {
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.payerRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/payers");
+            id = r.jsonPath().getString("data.payerId");
+            IdStore.put("payerId", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/receipts/ReceiptIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/receipts/ReceiptIT.java
@@ -1,0 +1,31 @@
+package com.easyreach.tests.receipts;
+
+import com.easyreach.tests.core.BaseIT;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class ReceiptIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldGetReceiptByOrder() {
+        given().spec(spec).get("/api/receipts/order/unknown")
+                .then().statusCode(anyOf(is(200), is(404)));
+    }
+
+    @Test
+    @Order(2)
+    void shouldGeneratePdf() {
+        given().spec(spec)
+                .multiPart("data", "{\"id\":1}")
+                .post("/api/receipts/pdf")
+                .then().statusCode(200);
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/sync/SyncIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/sync/SyncIT.java
@@ -1,0 +1,44 @@
+package com.easyreach.tests.sync;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.SampleData;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class SyncIT extends BaseIT {
+    private Map<String, Object> buildSyncRequest() {
+        Map<String, Object> company = SampleData.companyRequest();
+        Map<String, Object> payer = SampleData.payerRequest(company.get("uuid").toString());
+        Map<String, Object> vehicleType = SampleData.vehicleTypeRequest(company.get("uuid").toString());
+        Map<String, Object> entry = SampleData.vehicleEntryRequest(company.get("uuid").toString(),
+                payer.get("payerId").toString(), vehicleType.get("vehicleType").toString());
+        return SampleData.syncRequest(company, payer, vehicleType, entry);
+    }
+
+    @Test
+    @Order(1)
+    void shouldSyncEntities() {
+        Map<String, Object> body = buildSyncRequest();
+        given().spec(spec).body(body).post("/api/sync")
+                .then().statusCode(200)
+                .body("data", notNullValue());
+    }
+
+    @Test
+    @Order(2)
+    void shouldDownloadChanges() {
+        given().spec(spec).get("/api/sync/download?limit=10")
+                .then().statusCode(200)
+                .body("data", notNullValue());
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/tokens/RefreshTokenIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/tokens/RefreshTokenIT.java
@@ -1,0 +1,85 @@
+package com.easyreach.tests.tokens;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class RefreshTokenIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateRefreshToken() {
+        String userId = ensureUser();
+        Map<String, Object> body = SampleData.refreshTokenRequest(userId);
+        Response r = given().spec(spec).body(body).post("/api/refresh-token");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.jti");
+        IdStore.put("refreshTokenId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetRefreshToken() {
+        String id = IdStore.get("refreshTokenId");
+        given().spec(spec).get("/api/refresh-token/" + id)
+                .then().statusCode(200).body("data.jti", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListRefreshTokens() {
+        given().spec(spec).get("/api/refresh-token" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateRefreshToken() {
+        String id = IdStore.get("refreshTokenId");
+        String userId = IdStore.get("userId");
+        Map<String, Object> body = SampleData.refreshTokenRequest(userId);
+        body.put("jti", id);
+        given().spec(spec).body(body).put("/api/refresh-token/" + id)
+                .then().statusCode(200)
+                .body("data.jti", equalTo(id));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteRefreshToken() {
+        String id = IdStore.get("refreshTokenId");
+        given().spec(spec).delete("/api/refresh-token/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureUser() {
+        String id = IdStore.get("userId");
+        if (id == null) {
+            String companyId = IdStore.get("companyUuid");
+            if (companyId == null) {
+                Map<String, Object> company = SampleData.companyRequest();
+                Response cr = given().spec(spec).body(company).post("/api/companies");
+                companyId = cr.jsonPath().getString("data.uuid");
+                IdStore.put("companyUuid", companyId);
+            }
+            Map<String, Object> user = SampleData.userRequest(companyId);
+            Response ur = given().spec(spec).body(user).post("/api/users");
+            id = ur.jsonPath().getString("data.id");
+            IdStore.put("userId", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/users/UserIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/users/UserIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.users;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class UserIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateUser() {
+        String companyId = ensureCompany();
+        Map<String, Object> body = SampleData.userRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/users");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.id");
+        IdStore.put("userId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetUser() {
+        String id = IdStore.get("userId");
+        given().spec(spec).get("/api/users/" + id)
+                .then().statusCode(200).body("data.id", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListUsers() {
+        given().spec(spec).get("/api/users" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateUser() {
+        String id = IdStore.get("userId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.userRequest(companyId);
+        body.put("id", id);
+        body.put("name", "Updated User");
+        given().spec(spec).body(body).put("/api/users/" + id)
+                .then().statusCode(200)
+                .body("data.name", equalTo("Updated User"));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteUser() {
+        String id = IdStore.get("userId");
+        given().spec(spec).delete("/api/users/" + id)
+                .then().statusCode(200);
+    }
+
+    private String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/vehicles/InternalVehicleIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/vehicles/InternalVehicleIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.vehicles;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class InternalVehicleIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateInternalVehicle() {
+        String companyId = IdStore.get("companyUuid");
+        if (companyId == null) {
+            companyId = createCompany();
+        }
+        Map<String, Object> body = SampleData.internalVehicleRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/internal-vehicles");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.vehicleId");
+        IdStore.put("internalVehicleId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetInternalVehicle() {
+        String id = IdStore.get("internalVehicleId");
+        given().spec(spec).get("/api/internal-vehicles/" + id)
+                .then().statusCode(200).body("data.vehicleId", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListInternalVehicles() {
+        given().spec(spec).get("/api/internal-vehicles" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateInternalVehicle() {
+        String id = IdStore.get("internalVehicleId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.internalVehicleRequest(companyId);
+        body.put("vehicleId", id);
+        body.put("vehicleName", "UpdatedVehicle");
+        given().spec(spec).body(body).put("/api/internal-vehicles/" + id)
+                .then().statusCode(200)
+                .body("data.vehicleName", equalTo("UpdatedVehicle"));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteInternalVehicle() {
+        String id = IdStore.get("internalVehicleId");
+        given().spec(spec).delete("/api/internal-vehicles/" + id)
+                .then().statusCode(200);
+    }
+
+    private String createCompany() {
+        Map<String, Object> body = SampleData.companyRequest();
+        Response r = given().spec(spec).body(body).post("/api/companies");
+        String id = r.jsonPath().getString("data.uuid");
+        IdStore.put("companyUuid", id);
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/vehicles/VehicleTypeIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/vehicles/VehicleTypeIT.java
@@ -1,0 +1,79 @@
+package com.easyreach.tests.vehicles;
+
+import com.easyreach.tests.core.BaseIT;
+import com.easyreach.tests.core.IdStore;
+import com.easyreach.tests.core.SampleData;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@Tag("e2e")
+@TestMethodOrder(OrderAnnotation.class)
+public class VehicleTypeIT extends BaseIT {
+    @Test
+    @Order(1)
+    void shouldCreateVehicleType() {
+        String companyId = IdStore.get("companyUuid");
+        if (companyId == null) {
+            companyId = createCompany();
+        }
+        Map<String, Object> body = SampleData.vehicleTypeRequest(companyId);
+        Response r = given().spec(spec).body(body).post("/api/vehicle-types");
+        r.then().statusCode(200);
+        String id = r.jsonPath().getString("data.id");
+        IdStore.put("vehicleTypeId", id);
+    }
+
+    @Test
+    @Order(2)
+    void shouldGetVehicleType() {
+        String id = IdStore.get("vehicleTypeId");
+        given().spec(spec).get("/api/vehicle-types/" + id)
+                .then().statusCode(200).body("data.id", equalTo(id));
+    }
+
+    @Test
+    @Order(3)
+    void shouldListVehicleTypes() {
+        given().spec(spec).get("/api/vehicle-types" + pageable())
+                .then().statusCode(200)
+                .body("data.content", notNullValue());
+    }
+
+    @Test
+    @Order(4)
+    void shouldUpdateVehicleType() {
+        String id = IdStore.get("vehicleTypeId");
+        String companyId = IdStore.get("companyUuid");
+        Map<String, Object> body = SampleData.vehicleTypeRequest(companyId);
+        body.put("id", id);
+        body.put("vehicleType", "UpdatedType");
+        given().spec(spec).body(body).put("/api/vehicle-types/" + id)
+                .then().statusCode(200)
+                .body("data.vehicleType", equalTo("UpdatedType"));
+    }
+
+    @Test
+    @Order(5)
+    void shouldDeleteVehicleType() {
+        String id = IdStore.get("vehicleTypeId");
+        given().spec(spec).delete("/api/vehicle-types/" + id)
+                .then().statusCode(200);
+    }
+
+    private String createCompany() {
+        Map<String, Object> body = SampleData.companyRequest();
+        Response r = given().spec(spec).body(body).post("/api/companies");
+        String id = r.jsonPath().getString("data.uuid");
+        IdStore.put("companyUuid", id);
+        return id;
+    }
+}

--- a/api-tests/src/test/resources/openapi.json
+++ b/api-tests/src/test/resources/openapi.json
@@ -1,8 +1,1 @@
-{
-  "openapi": "3.0.3",
-  "info": {
-    "title": "EasyReach API",
-    "version": "1.0.0"
-  },
-  "paths": {}
-}
+{ "openapi": "3.0.1", "info": { "title": "Easyreach API", "version": "v1" } }


### PR DESCRIPTION
## Summary
- add shared test utilities and auth helpers for API testing
- generate sample data factories and ID store
- implement CRUD/ops tests for companies, vehicles, ledger, payers, users, tokens, receipts and sync endpoints

## Testing
- `mvn -q -pl api-tests -am test -DBASE_URL=http://localhost:8080 -DAUTH_EMAIL=admin@local -DAUTH_PASSWORD=admin` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc51f4379c832d99013fd7dbaeb951