### PR TITLE
Add API contract validation and Postman tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,23 @@ mvn -q clean verify
 
 The JaCoCo coverage report is generated at:
 `target/site/jacoco/index.html`
+
+## API contract tools
+
+Refresh the OpenAPI specification before running the API tests:
+
+```bash
+scripts/fetch-openapi.sh
+```
+
+Generate a Postman collection from the spec:
+
+```bash
+scripts/generate-postman.sh
+```
+
+Run fast smoke tests with Newman (set `BASE_URL` and `TOKEN` as needed):
+
+```bash
+scripts/newman-smoke.sh
+```

--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -26,6 +26,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.atlassian.oai</groupId>
+            <artifactId>swagger-request-validator-restassured</artifactId>
+            <version>2.37.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.17.1</version>
@@ -59,6 +65,30 @@
                 <configuration>
                     <useModulePath>false</useModulePath>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>fetch-openapi-spec</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>curl</executable>
+                            <arguments>
+                                <argument>-s</argument>
+                                <argument>http://localhost:8080/v3/api-docs</argument>
+                                <argument>-o</argument>
+                                <argument>${project.basedir}/src/test/resources/openapi.json</argument>
+                            </arguments>
+                            <ignoreExitValue>true</ignoreExitValue>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api-tests/src/test/java/com/easyreach/tests/core/BaseIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/core/BaseIT.java
@@ -1,5 +1,6 @@
 package com.easyreach.tests.core;
 
+import com.atlassian.oai.validator.restassured.OpenApiValidationFilter;
 import com.easyreach.tests.auth.AuthClient;
 import com.easyreach.tests.config.TestConfig;
 import io.restassured.builder.RequestSpecBuilder;
@@ -9,6 +10,8 @@ import org.junit.jupiter.api.BeforeAll;
 
 public abstract class BaseIT {
     protected static RequestSpecification spec;
+    private static final OpenApiValidationFilter OAS =
+            new OpenApiValidationFilter("src/test/resources/openapi.json");
 
     @BeforeAll
     static void initSpec() {
@@ -16,6 +19,7 @@ public abstract class BaseIT {
                 .setBaseUri(TestConfig.getBaseUrl())
                 .setContentType(ContentType.JSON)
                 .addHeader("Authorization", "Bearer " + AuthClient.getAccessToken())
+                .addFilter(OAS)
                 .build();
     }
 

--- a/scripts/fetch-openapi.sh
+++ b/scripts/fetch-openapi.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -euo pipefail
+curl -s http://localhost:8080/v3/api-docs -o api-tests/src/test/resources/openapi.json

--- a/scripts/generate-postman.sh
+++ b/scripts/generate-postman.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+mkdir -p postman
+npx openapi-to-postmanv2 -s api-tests/src/test/resources/openapi.json -o postman/Easyreach.postman.json -p

--- a/scripts/newman-smoke.sh
+++ b/scripts/newman-smoke.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+BASE_URL=${BASE_URL:-http://localhost:8080}
+TOKEN=${TOKEN:-}
+newman run postman/Easyreach.postman.json --env-var baseUrl=$BASE_URL --env-var token="$TOKEN"


### PR DESCRIPTION
## Summary
- validate API requests against the OpenAPI spec using Rest Assured
- document and script OpenAPI spec refresh, Postman generation, and Newman smoke tests

## Testing
- `mvn -q -pl api-tests -am verify` *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68bc59d3b7c0832d8ebf9002d340a7c8