### PR TITLE
Add 404 responses for path-parameter endpoints

### DIFF
--- a/api-tests/src/test/resources/openapi.json
+++ b/api-tests/src/test/resources/openapi.json
@@ -43,6 +43,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -87,6 +90,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -121,6 +127,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -157,6 +166,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -201,6 +213,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -235,6 +250,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -271,6 +289,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -315,6 +336,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -349,6 +373,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -385,6 +412,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         }
       },
@@ -424,6 +454,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         }
       },
@@ -453,6 +486,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         }
       }
@@ -484,6 +520,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -528,6 +567,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -562,6 +604,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -598,6 +643,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -642,6 +690,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -676,6 +727,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -712,6 +766,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -756,6 +813,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -790,6 +850,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -826,6 +889,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -870,6 +936,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -904,6 +973,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -940,6 +1012,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -984,6 +1059,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1018,6 +1096,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1054,6 +1135,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1098,6 +1182,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1132,6 +1219,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1168,6 +1258,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1212,6 +1305,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1246,6 +1342,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1282,6 +1381,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1326,6 +1428,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1360,6 +1465,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1659,6 +1767,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -1704,6 +1815,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -2101,6 +2215,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -2631,6 +2748,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         }
       }
@@ -2714,6 +2834,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -2750,6 +2873,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -2830,6 +2956,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [
@@ -2892,6 +3021,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found"
           }
         },
         "security": [

--- a/postman/Easyreach.postman.json
+++ b/postman/Easyreach.postman.json
@@ -1,0 +1,11186 @@
+{
+    "item": [
+        {
+            "name": "api",
+            "description": "",
+            "item": [
+                {
+                    "name": "vehicle-types",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "0b818d4b-f386-42b4-85e5-fa7acb796477",
+                                    "name": "Get VehicleType",
+                                    "request": {
+                                        "name": "Get VehicleType",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-types",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "8bab943a-6df9-4102-b217-e27707b23ffd",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-types",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"type\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "31328242-b2e2-44aa-88c8-860d8bfeb43b",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-types",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "ff31668c-abcb-4e77-9f04-9606e1fe8d1b",
+                                    "name": "Update VehicleType",
+                                    "request": {
+                                        "name": "Update VehicleType",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-types",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"type\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleType\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "4e5fe400-c152-43cb-9683-42f401e79a0f",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-types",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"type\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleType\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"type\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "16e33f08-d540-47d3-a888-ffac273a65a3",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-types",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"type\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleType\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "6f07c826-ca2e-4ac3-9297-9343d5439663",
+                                    "name": "Delete VehicleType",
+                                    "request": {
+                                        "name": "Delete VehicleType",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-types",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "04ddfce4-1db8-4a6d-b0d6-01a775199c9c",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-types",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "0cab7a2a-73c5-45f6-9a57-c3e84edf638a",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-types",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "4282dc55-e0be-4d1e-834f-a9fcf306a744",
+                            "name": "List VehicleType",
+                            "request": {
+                                "name": "List VehicleType",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "vehicle-types"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "d1476a53-b11c-4289-b3a9-2b06e9fc557e",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-types"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"id\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"type\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"id\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"type\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "a36ed7fc-691f-4fc3-83b0-d062af9952e6",
+                            "name": "Create VehicleType",
+                            "request": {
+                                "name": "Create VehicleType",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "vehicle-types"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"type\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleType\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "4ab4919d-8e18-43a1-a6a9-59680c220532",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-types"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"type\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleType\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"type\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "vehicle-entries",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "ad04374d-88f3-4657-8224-673073bbdd35",
+                                    "name": "Get VehicleEntry",
+                                    "request": {
+                                        "name": "Get VehicleEntry",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-entries",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "eb018e6a-7f31-4631-abe8-3e98c5f841d5",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"entryId\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"vehicleNumber\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"fromAddress\": \"<string>\",\n    \"toAddress\": \"<string>\",\n    \"driverName\": \"<string>\",\n    \"driverContactNo\": \"<string>\",\n    \"commission\": \"<number>\",\n    \"beta\": \"<number>\",\n    \"referredBy\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"paytype\": \"<string>\",\n    \"entryDate\": \"<date>\",\n    \"entryTime\": \"<dateTime>\",\n    \"exitTime\": \"<dateTime>\",\n    \"notes\": \"<string>\",\n    \"paymentReceivedBy\": \"<string>\",\n    \"paidAmount\": \"<number>\",\n    \"pendingAmt\": \"<number>\",\n    \"isSettled\": \"<boolean>\",\n    \"settlementType\": \"<string>\",\n    \"settlementDate\": \"<dateTime>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "06a09100-981e-4536-b1e2-86ed00d5932d",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "7aaa14a6-f3bb-404a-8386-3db2d1238373",
+                                    "name": "Update VehicleEntry",
+                                    "request": {
+                                        "name": "Update VehicleEntry",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-entries",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"beta\": \"<number>\",\n  \"commission\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"driverContactNo\": \"<string>\",\n  \"driverName\": \"<string>\",\n  \"entryDate\": \"<date>\",\n  \"entryId\": \"<string>\",\n  \"entryTime\": \"<dateTime>\",\n  \"fromAddress\": \"<string>\",\n  \"isSettled\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"paidAmount\": \"<number>\",\n  \"payerId\": \"<string>\",\n  \"paytype\": \"<string>\",\n  \"pendingAmt\": \"<number>\",\n  \"toAddress\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleNumber\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"referredBy\": \"<string>\",\n  \"exitTime\": \"<dateTime>\",\n  \"notes\": \"<string>\",\n  \"paymentReceivedBy\": \"<string>\",\n  \"settlementType\": \"<string>\",\n  \"settlementDate\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "3bbc0a9e-f1fe-4bf2-8038-49f3e0e75ce4",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"beta\": \"<number>\",\n  \"commission\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"driverContactNo\": \"<string>\",\n  \"driverName\": \"<string>\",\n  \"entryDate\": \"<date>\",\n  \"entryId\": \"<string>\",\n  \"entryTime\": \"<dateTime>\",\n  \"fromAddress\": \"<string>\",\n  \"isSettled\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"paidAmount\": \"<number>\",\n  \"payerId\": \"<string>\",\n  \"paytype\": \"<string>\",\n  \"pendingAmt\": \"<number>\",\n  \"toAddress\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleNumber\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"referredBy\": \"<string>\",\n  \"exitTime\": \"<dateTime>\",\n  \"notes\": \"<string>\",\n  \"paymentReceivedBy\": \"<string>\",\n  \"settlementType\": \"<string>\",\n  \"settlementDate\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"entryId\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"vehicleNumber\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"fromAddress\": \"<string>\",\n    \"toAddress\": \"<string>\",\n    \"driverName\": \"<string>\",\n    \"driverContactNo\": \"<string>\",\n    \"commission\": \"<number>\",\n    \"beta\": \"<number>\",\n    \"referredBy\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"paytype\": \"<string>\",\n    \"entryDate\": \"<date>\",\n    \"entryTime\": \"<dateTime>\",\n    \"exitTime\": \"<dateTime>\",\n    \"notes\": \"<string>\",\n    \"paymentReceivedBy\": \"<string>\",\n    \"paidAmount\": \"<number>\",\n    \"pendingAmt\": \"<number>\",\n    \"isSettled\": \"<boolean>\",\n    \"settlementType\": \"<string>\",\n    \"settlementDate\": \"<dateTime>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "7a2dde6e-bf76-46e9-9b70-0fe2ac41a455",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"beta\": \"<number>\",\n  \"commission\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"driverContactNo\": \"<string>\",\n  \"driverName\": \"<string>\",\n  \"entryDate\": \"<date>\",\n  \"entryId\": \"<string>\",\n  \"entryTime\": \"<dateTime>\",\n  \"fromAddress\": \"<string>\",\n  \"isSettled\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"paidAmount\": \"<number>\",\n  \"payerId\": \"<string>\",\n  \"paytype\": \"<string>\",\n  \"pendingAmt\": \"<number>\",\n  \"toAddress\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleNumber\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"referredBy\": \"<string>\",\n  \"exitTime\": \"<dateTime>\",\n  \"notes\": \"<string>\",\n  \"paymentReceivedBy\": \"<string>\",\n  \"settlementType\": \"<string>\",\n  \"settlementDate\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "e125ae49-e059-47e1-90e9-7df672a6bbf8",
+                                    "name": "Delete VehicleEntry",
+                                    "request": {
+                                        "name": "Delete VehicleEntry",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-entries",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "bd52cc4d-f4aa-45aa-bb9f-3f9d176f3c71",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "8f417a82-cfbb-4e16-9c8a-bd84cc5d731b",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "dfbe57d4-178b-4cc0-912e-386de1d8b41d",
+                            "name": "List VehicleEntry",
+                            "request": {
+                                "name": "List VehicleEntry",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "vehicle-entries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "cc0d14a6-99f0-4c78-b2e3-ccfb99dcee0f",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-entries"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"entryId\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"vehicleNumber\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"fromAddress\": \"<string>\",\n        \"toAddress\": \"<string>\",\n        \"driverName\": \"<string>\",\n        \"driverContactNo\": \"<string>\",\n        \"commission\": \"<number>\",\n        \"beta\": \"<number>\",\n        \"referredBy\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"paytype\": \"<string>\",\n        \"entryDate\": \"<date>\",\n        \"entryTime\": \"<dateTime>\",\n        \"exitTime\": \"<dateTime>\",\n        \"notes\": \"<string>\",\n        \"paymentReceivedBy\": \"<string>\",\n        \"paidAmount\": \"<number>\",\n        \"pendingAmt\": \"<number>\",\n        \"isSettled\": \"<boolean>\",\n        \"settlementType\": \"<string>\",\n        \"settlementDate\": \"<dateTime>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"entryId\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"vehicleNumber\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"fromAddress\": \"<string>\",\n        \"toAddress\": \"<string>\",\n        \"driverName\": \"<string>\",\n        \"driverContactNo\": \"<string>\",\n        \"commission\": \"<number>\",\n        \"beta\": \"<number>\",\n        \"referredBy\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"paytype\": \"<string>\",\n        \"entryDate\": \"<date>\",\n        \"entryTime\": \"<dateTime>\",\n        \"exitTime\": \"<dateTime>\",\n        \"notes\": \"<string>\",\n        \"paymentReceivedBy\": \"<string>\",\n        \"paidAmount\": \"<number>\",\n        \"pendingAmt\": \"<number>\",\n        \"isSettled\": \"<boolean>\",\n        \"settlementType\": \"<string>\",\n        \"settlementDate\": \"<dateTime>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "3f360759-5a26-4269-ad26-3a4a6d4caabf",
+                            "name": "Create VehicleEntry",
+                            "request": {
+                                "name": "Create VehicleEntry",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "vehicle-entries"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"beta\": \"<number>\",\n  \"commission\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"driverContactNo\": \"<string>\",\n  \"driverName\": \"<string>\",\n  \"entryDate\": \"<date>\",\n  \"entryId\": \"<string>\",\n  \"entryTime\": \"<dateTime>\",\n  \"fromAddress\": \"<string>\",\n  \"isSettled\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"paidAmount\": \"<number>\",\n  \"payerId\": \"<string>\",\n  \"paytype\": \"<string>\",\n  \"pendingAmt\": \"<number>\",\n  \"toAddress\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleNumber\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"referredBy\": \"<string>\",\n  \"exitTime\": \"<dateTime>\",\n  \"notes\": \"<string>\",\n  \"paymentReceivedBy\": \"<string>\",\n  \"settlementType\": \"<string>\",\n  \"settlementDate\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "444f397b-d6a7-45bd-9f00-8295d09d4ff0",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "vehicle-entries"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"beta\": \"<number>\",\n  \"commission\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"driverContactNo\": \"<string>\",\n  \"driverName\": \"<string>\",\n  \"entryDate\": \"<date>\",\n  \"entryId\": \"<string>\",\n  \"entryTime\": \"<dateTime>\",\n  \"fromAddress\": \"<string>\",\n  \"isSettled\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"paidAmount\": \"<number>\",\n  \"payerId\": \"<string>\",\n  \"paytype\": \"<string>\",\n  \"pendingAmt\": \"<number>\",\n  \"toAddress\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleNumber\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"referredBy\": \"<string>\",\n  \"exitTime\": \"<dateTime>\",\n  \"notes\": \"<string>\",\n  \"paymentReceivedBy\": \"<string>\",\n  \"settlementType\": \"<string>\",\n  \"settlementDate\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"entryId\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"vehicleNumber\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"fromAddress\": \"<string>\",\n    \"toAddress\": \"<string>\",\n    \"driverName\": \"<string>\",\n    \"driverContactNo\": \"<string>\",\n    \"commission\": \"<number>\",\n    \"beta\": \"<number>\",\n    \"referredBy\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"paytype\": \"<string>\",\n    \"entryDate\": \"<date>\",\n    \"entryTime\": \"<dateTime>\",\n    \"exitTime\": \"<dateTime>\",\n    \"notes\": \"<string>\",\n    \"paymentReceivedBy\": \"<string>\",\n    \"paidAmount\": \"<number>\",\n    \"pendingAmt\": \"<number>\",\n    \"isSettled\": \"<boolean>\",\n    \"settlementType\": \"<string>\",\n    \"settlementDate\": \"<dateTime>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "users",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "5ca0139e-bad9-4ad0-8dfc-a23a6ba2e154",
+                                    "name": "Get User",
+                                    "request": {
+                                        "name": "Get User",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "users",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "67686d4c-98bb-4bc9-93e1-129b5dedd348",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "users",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"employeeId\": \"<string>\",\n    \"email\": \"<string>\",\n    \"mobileNo\": \"<string>\",\n    \"password\": \"<string>\",\n    \"role\": \"<string>\",\n    \"name\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"companyCode\": \"<string>\",\n    \"createdBy\": \"<string>\",\n    \"location\": \"<string>\",\n    \"dateOfBirth\": \"<date>\",\n    \"joiningDate\": \"<date>\",\n    \"isActive\": \"<boolean>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "5c119514-0bab-4f40-9b89-0425a1111b48",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "users",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "71234db9-e5a8-4f5b-b238-27267777b9db",
+                                    "name": "Update User",
+                                    "request": {
+                                        "name": "Update User",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "users",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"employeeId\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isActive\": \"<boolean>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"companyCode\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<date>\",\n  \"joiningDate\": \"<date>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "8950bda6-c6a6-422c-a3d6-0b95526b3d86",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "users",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"employeeId\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isActive\": \"<boolean>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"companyCode\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<date>\",\n  \"joiningDate\": \"<date>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"employeeId\": \"<string>\",\n    \"email\": \"<string>\",\n    \"mobileNo\": \"<string>\",\n    \"password\": \"<string>\",\n    \"role\": \"<string>\",\n    \"name\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"companyCode\": \"<string>\",\n    \"createdBy\": \"<string>\",\n    \"location\": \"<string>\",\n    \"dateOfBirth\": \"<date>\",\n    \"joiningDate\": \"<date>\",\n    \"isActive\": \"<boolean>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "2f4aced9-693f-4d82-ae80-5ad9d1d409da",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "users",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"employeeId\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isActive\": \"<boolean>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"companyCode\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<date>\",\n  \"joiningDate\": \"<date>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "eed32eab-2eaa-4690-bd15-621bea70897b",
+                                    "name": "Delete User",
+                                    "request": {
+                                        "name": "Delete User",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "users",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "1ce82aa4-5b35-4030-b9e9-88c3fc192b14",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "users",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "90ee0a8f-d207-4d69-bd6d-ecf85ea7353f",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "users",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "2fe3b558-15bf-400e-8bf5-253794e1597a",
+                            "name": "List User",
+                            "request": {
+                                "name": "List User",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "3030225b-800f-4551-88ba-90ea55e1d414",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "users"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"id\": \"<string>\",\n        \"employeeId\": \"<string>\",\n        \"email\": \"<string>\",\n        \"mobileNo\": \"<string>\",\n        \"password\": \"<string>\",\n        \"role\": \"<string>\",\n        \"name\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"companyCode\": \"<string>\",\n        \"createdBy\": \"<string>\",\n        \"location\": \"<string>\",\n        \"dateOfBirth\": \"<date>\",\n        \"joiningDate\": \"<date>\",\n        \"isActive\": \"<boolean>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"id\": \"<string>\",\n        \"employeeId\": \"<string>\",\n        \"email\": \"<string>\",\n        \"mobileNo\": \"<string>\",\n        \"password\": \"<string>\",\n        \"role\": \"<string>\",\n        \"name\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"companyCode\": \"<string>\",\n        \"createdBy\": \"<string>\",\n        \"location\": \"<string>\",\n        \"dateOfBirth\": \"<date>\",\n        \"joiningDate\": \"<date>\",\n        \"isActive\": \"<boolean>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "2f6a4833-bb2f-47c5-8fa5-8152591b5134",
+                            "name": "Create User",
+                            "request": {
+                                "name": "Create User",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "users"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"employeeId\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isActive\": \"<boolean>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"companyCode\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<date>\",\n  \"joiningDate\": \"<date>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "5c42eaa2-df95-4325-bdc2-7e276a1ee0c0",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "users"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"employeeId\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isActive\": \"<boolean>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"companyCode\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<date>\",\n  \"joiningDate\": \"<date>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"employeeId\": \"<string>\",\n    \"email\": \"<string>\",\n    \"mobileNo\": \"<string>\",\n    \"password\": \"<string>\",\n    \"role\": \"<string>\",\n    \"name\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"companyCode\": \"<string>\",\n    \"createdBy\": \"<string>\",\n    \"location\": \"<string>\",\n    \"dateOfBirth\": \"<date>\",\n    \"joiningDate\": \"<date>\",\n    \"isActive\": \"<boolean>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "refresh-token",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "e2d71230-04ac-45ec-a987-de28d647faa7",
+                                    "name": "Get RefreshToken",
+                                    "request": {
+                                        "name": "Get RefreshToken",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "refresh-token",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": null
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "b59c926f-dde3-452a-80e0-039e0fdc4b2b",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "refresh-token",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"jti\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"issuedAt\": \"<dateTime>\",\n    \"expiresAt\": \"<dateTime>\",\n    \"revokedAt\": \"<dateTime>\",\n    \"rotatedFromJti\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "31a755ea-21a2-4124-a954-dd6053dc5a55",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "refresh-token",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "80352d77-93c7-41e2-9e58-ccb9280f12f0",
+                                    "name": "Update RefreshToken",
+                                    "request": {
+                                        "name": "Update RefreshToken",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "refresh-token",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"expiresAt\": \"<dateTime>\",\n  \"issuedAt\": \"<dateTime>\",\n  \"jti\": \"<string>\",\n  \"userId\": \"<string>\",\n  \"revokedAt\": \"<dateTime>\",\n  \"rotatedFromJti\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"createdBy\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedBy\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": null
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "383cd126-6bfc-4742-924c-9b651f72381f",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "refresh-token",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"expiresAt\": \"<dateTime>\",\n  \"issuedAt\": \"<dateTime>\",\n  \"jti\": \"<string>\",\n  \"userId\": \"<string>\",\n  \"revokedAt\": \"<dateTime>\",\n  \"rotatedFromJti\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"createdBy\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedBy\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"jti\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"issuedAt\": \"<dateTime>\",\n    \"expiresAt\": \"<dateTime>\",\n    \"revokedAt\": \"<dateTime>\",\n    \"rotatedFromJti\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "11f472d4-0fb2-4989-b3df-754364f3c07e",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "refresh-token",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"expiresAt\": \"<dateTime>\",\n  \"issuedAt\": \"<dateTime>\",\n  \"jti\": \"<string>\",\n  \"userId\": \"<string>\",\n  \"revokedAt\": \"<dateTime>\",\n  \"rotatedFromJti\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"createdBy\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedBy\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "26ef81d5-53dd-40c2-a76d-dae0152ab30e",
+                                    "name": "Delete RefreshToken",
+                                    "request": {
+                                        "name": "Delete RefreshToken",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "refresh-token",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": null
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "65679a4e-3a71-4e7d-a9d9-bdbb5554f8b0",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "refresh-token",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "b97e053a-2b0a-46e5-86f7-8219d8219d83",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "refresh-token",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "111a9116-ace4-4fda-820c-dc9cedf86b96",
+                            "name": "List RefreshToken",
+                            "request": {
+                                "name": "List RefreshToken",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "refresh-token"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "f44373ae-b3ac-4726-a673-538edaa6399f",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "refresh-token"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"jti\": \"<string>\",\n        \"userId\": \"<string>\",\n        \"issuedAt\": \"<dateTime>\",\n        \"expiresAt\": \"<dateTime>\",\n        \"revokedAt\": \"<dateTime>\",\n        \"rotatedFromJti\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\"\n      },\n      {\n        \"jti\": \"<string>\",\n        \"userId\": \"<string>\",\n        \"issuedAt\": \"<dateTime>\",\n        \"expiresAt\": \"<dateTime>\",\n        \"revokedAt\": \"<dateTime>\",\n        \"rotatedFromJti\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "1c9ad1a0-c75f-4196-bb64-3a1117ebe163",
+                            "name": "Create RefreshToken",
+                            "request": {
+                                "name": "Create RefreshToken",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "refresh-token"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"expiresAt\": \"<dateTime>\",\n  \"issuedAt\": \"<dateTime>\",\n  \"jti\": \"<string>\",\n  \"userId\": \"<string>\",\n  \"revokedAt\": \"<dateTime>\",\n  \"rotatedFromJti\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"createdBy\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedBy\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "5e5dd97e-9d20-4536-b5d7-04266ff57485",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "refresh-token"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"expiresAt\": \"<dateTime>\",\n  \"issuedAt\": \"<dateTime>\",\n  \"jti\": \"<string>\",\n  \"userId\": \"<string>\",\n  \"revokedAt\": \"<dateTime>\",\n  \"rotatedFromJti\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"createdBy\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"updatedBy\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"jti\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"issuedAt\": \"<dateTime>\",\n    \"expiresAt\": \"<dateTime>\",\n    \"revokedAt\": \"<dateTime>\",\n    \"rotatedFromJti\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "payers",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "2f762d88-4f1b-4f7c-b256-e00816dc3776",
+                                    "name": "Get Payer",
+                                    "request": {
+                                        "name": "Get Payer",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "19eb1873-8112-4abe-b093-599a0d1d5429",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"payerId\": \"<string>\",\n    \"payerName\": \"<string>\",\n    \"mobileNo\": \"<string>\",\n    \"payerAddress\": \"<string>\",\n    \"registrationDate\": \"<date>\",\n    \"creditLimit\": \"<integer>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "ea5de346-641b-4a05-94de-c414f244100b",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "9de9e5d1-df41-4b2b-a8ee-a5b877e2e0bc",
+                                    "name": "Update Payer",
+                                    "request": {
+                                        "name": "Update Payer",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"mobileNo\": \"<string>\",\n  \"payerId\": \"<string>\",\n  \"payerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"payerAddress\": \"<string>\",\n  \"registrationDate\": \"<date>\",\n  \"creditLimit\": \"<integer>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "35fb737c-cf13-4a8a-a956-f61cda7b3e18",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"mobileNo\": \"<string>\",\n  \"payerId\": \"<string>\",\n  \"payerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"payerAddress\": \"<string>\",\n  \"registrationDate\": \"<date>\",\n  \"creditLimit\": \"<integer>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"payerId\": \"<string>\",\n    \"payerName\": \"<string>\",\n    \"mobileNo\": \"<string>\",\n    \"payerAddress\": \"<string>\",\n    \"registrationDate\": \"<date>\",\n    \"creditLimit\": \"<integer>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "08eaa2a4-61dc-4f95-903e-e403c0c6f05d",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"mobileNo\": \"<string>\",\n  \"payerId\": \"<string>\",\n  \"payerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"payerAddress\": \"<string>\",\n  \"registrationDate\": \"<date>\",\n  \"creditLimit\": \"<integer>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "bb8d192e-ccc6-434b-b166-a3c9dd1fe02d",
+                                    "name": "Delete Payer",
+                                    "request": {
+                                        "name": "Delete Payer",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payers",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "769fedd5-8f93-442c-979d-c1cb90f55553",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "22feb686-f030-4dd9-a2b1-a17184d2926b",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "39f23984-f79e-4a50-a4aa-379dfc0e3bef",
+                            "name": "List Payer",
+                            "request": {
+                                "name": "List Payer",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "payers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "c9dffece-83cc-463d-9577-ebf76d5d8ae8",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payers"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"payerId\": \"<string>\",\n        \"payerName\": \"<string>\",\n        \"mobileNo\": \"<string>\",\n        \"payerAddress\": \"<string>\",\n        \"registrationDate\": \"<date>\",\n        \"creditLimit\": \"<integer>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"payerId\": \"<string>\",\n        \"payerName\": \"<string>\",\n        \"mobileNo\": \"<string>\",\n        \"payerAddress\": \"<string>\",\n        \"registrationDate\": \"<date>\",\n        \"creditLimit\": \"<integer>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "b6a83fce-142c-4afa-a9d9-da778bd7d556",
+                            "name": "Create Payer",
+                            "request": {
+                                "name": "Create Payer",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "payers"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"mobileNo\": \"<string>\",\n  \"payerId\": \"<string>\",\n  \"payerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"payerAddress\": \"<string>\",\n  \"registrationDate\": \"<date>\",\n  \"creditLimit\": \"<integer>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "d36457c5-4890-4108-8b5c-d32f55d1e972",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payers"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"mobileNo\": \"<string>\",\n  \"payerId\": \"<string>\",\n  \"payerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"payerAddress\": \"<string>\",\n  \"registrationDate\": \"<date>\",\n  \"creditLimit\": \"<integer>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"payerId\": \"<string>\",\n    \"payerName\": \"<string>\",\n    \"mobileNo\": \"<string>\",\n    \"payerAddress\": \"<string>\",\n    \"registrationDate\": \"<date>\",\n    \"creditLimit\": \"<integer>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "payer-settlements",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "2bee88bf-af44-4b2a-9440-ced59a1bcc9f",
+                                    "name": "Get PayerSettlement",
+                                    "request": {
+                                        "name": "Get PayerSettlement",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payer-settlements",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "1560609a-4ab2-4cc0-b6f5-a8b208cfe454",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"settlementId\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"date\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "75b691c3-8bfd-4958-9b5b-44247e2da97b",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "a12ce372-48ae-424a-a3ee-4466b6cc49a9",
+                                    "name": "Update PayerSettlement",
+                                    "request": {
+                                        "name": "Update PayerSettlement",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payer-settlements",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"payerId\": \"<string>\",\n  \"settlementId\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "a5207355-60f8-4007-9c84-d19b2e63b3e9",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"payerId\": \"<string>\",\n  \"settlementId\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"settlementId\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"date\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "768f64e1-96b4-48cc-be82-686b1482a593",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"payerId\": \"<string>\",\n  \"settlementId\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "0f34e98f-68b5-4f9b-bafb-ab9e18d0ee6c",
+                                    "name": "Delete PayerSettlement",
+                                    "request": {
+                                        "name": "Delete PayerSettlement",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payer-settlements",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "d86a90cf-651a-49e0-8635-eb9407aa110a",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "dbb807e5-175c-491f-bd26-108eea517af5",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "e2c89b5e-c456-4878-98bc-568773bf1b72",
+                            "name": "List PayerSettlement",
+                            "request": {
+                                "name": "List PayerSettlement",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "payer-settlements"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "429aa3c4-dbff-4f2f-8149-cfe0bc7c861c",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payer-settlements"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"settlementId\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"date\": \"<dateTime>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"settlementId\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"date\": \"<dateTime>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "b2bfba89-9839-406c-b9d5-7c2c13019ab2",
+                            "name": "Create PayerSettlement",
+                            "request": {
+                                "name": "Create PayerSettlement",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "payer-settlements"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"payerId\": \"<string>\",\n  \"settlementId\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "3f35b59c-989b-44ab-9569-ac22732f3e32",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payer-settlements"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"payerId\": \"<string>\",\n  \"settlementId\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"settlementId\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"date\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "name": "payer",
+                            "description": "",
+                            "item": [
+                                {
+                                    "name": "{payerId}",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "723e8e76-f78f-4f36-be09-0bb1bbe61653",
+                                            "name": "List settlements by payer",
+                                            "request": {
+                                                "name": "List settlements by payer",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        "payer",
+                                                        ":payerId"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "payerId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {},
+                                                "auth": {
+                                                    "type": "bearer",
+                                                    "bearer": [
+                                                        {
+                                                            "key": "token",
+                                                            "value": "{{bearerToken}}"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "67e73812-9a4e-4fdc-be1a-537a1e4936ae",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "payer-settlements",
+                                                                "payer",
+                                                                ":payerId"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "GET",
+                                                        "body": {}
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": [\n    {\n      \"settlementId\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"amount\": \"<number>\",\n      \"date\": \"<dateTime>\"\n    },\n    {\n      \"settlementId\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"amount\": \"<number>\",\n      \"date\": \"<dateTime>\"\n    }\n  ],\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "0836d785-9d4a-4f45-ad27-c52de7c00726",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "payer-settlements",
+                                                                "payer",
+                                                                ":payerId"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "GET",
+                                                        "body": {}
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "name": "company",
+                            "description": "",
+                            "item": [
+                                {
+                                    "name": "{companyId}",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "b12312fa-e7d4-4f98-b0b7-5fb795a9981b",
+                                            "name": "List settlements by company",
+                                            "request": {
+                                                "name": "List settlements by company",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payer-settlements",
+                                                        "company",
+                                                        ":companyId"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "companyId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {},
+                                                "auth": {
+                                                    "type": "bearer",
+                                                    "bearer": [
+                                                        {
+                                                            "key": "token",
+                                                            "value": "{{bearerToken}}"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "df87dea9-183b-4867-9c7a-11ec14dc2db2",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "payer-settlements",
+                                                                "company",
+                                                                ":companyId"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "GET",
+                                                        "body": {}
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": [\n    {\n      \"settlementId\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"amount\": \"<number>\",\n      \"date\": \"<dateTime>\"\n    },\n    {\n      \"settlementId\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"amount\": \"<number>\",\n      \"date\": \"<dateTime>\"\n    }\n  ],\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "bdf59aae-571b-47b7-adf3-62707e4bd2ab",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "payer-settlements",
+                                                                "company",
+                                                                ":companyId"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "GET",
+                                                        "body": {}
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "internal-vehicles",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "efd1750a-5083-4abe-b789-de37b9199692",
+                                    "name": "Get InternalVehicle",
+                                    "request": {
+                                        "name": "Get InternalVehicle",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "internal-vehicles",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "5318f0cd-5624-4b35-97b2-ac27f503d6b4",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "internal-vehicles",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"vehicleId\": \"<string>\",\n    \"vehicleName\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "c15eae1f-9503-4d56-b625-b832e8e18702",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "internal-vehicles",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "f68e774f-f2cd-4bfd-bdaa-5aebf6b66819",
+                                    "name": "Update InternalVehicle",
+                                    "request": {
+                                        "name": "Update InternalVehicle",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "internal-vehicles",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleId\": \"<string>\",\n  \"vehicleName\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "ca6a015d-c64e-4a4b-9ae4-bd6e9ff9fea6",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "internal-vehicles",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleId\": \"<string>\",\n  \"vehicleName\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"vehicleId\": \"<string>\",\n    \"vehicleName\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "c60c138f-48b1-46a3-88be-a4a707754551",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "internal-vehicles",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleId\": \"<string>\",\n  \"vehicleName\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "10dab5c4-bf68-4ce2-90fc-d5ad1eabd1a7",
+                                    "name": "Delete InternalVehicle",
+                                    "request": {
+                                        "name": "Delete InternalVehicle",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "internal-vehicles",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "69282923-1f5a-4054-81d6-25f04f4ec4e4",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "internal-vehicles",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "95bb8880-a36a-45ab-b498-e0b47b90e399",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "internal-vehicles",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "196aabb8-e4cd-42ba-b838-8529155acce2",
+                            "name": "List InternalVehicle",
+                            "request": {
+                                "name": "List InternalVehicle",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "internal-vehicles"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "4259270c-ab45-43f2-a5ac-4a8caf70f4d8",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "internal-vehicles"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"vehicleId\": \"<string>\",\n        \"vehicleName\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"vehicleId\": \"<string>\",\n        \"vehicleName\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"isActive\": \"<boolean>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "3c30ba5e-9cb4-4b39-9367-de3ab50ad8e7",
+                            "name": "Create InternalVehicle",
+                            "request": {
+                                "name": "Create InternalVehicle",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "internal-vehicles"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleId\": \"<string>\",\n  \"vehicleName\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "7b460846-b852-4000-a9ff-fb32f1a75ae1",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "internal-vehicles"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleId\": \"<string>\",\n  \"vehicleName\": \"<string>\",\n  \"vehicleType\": \"<string>\",\n  \"companyUuid\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"vehicleId\": \"<string>\",\n    \"vehicleName\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"isActive\": \"<boolean>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "expense-master",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "6523cf46-4f5b-40be-9707-3020f4a629ac",
+                                    "name": "Get ExpenseMaster",
+                                    "request": {
+                                        "name": "Get ExpenseMaster",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "expense-master",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "f8b940af-8414-42ec-8a78-51dcb40d0455",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "expense-master",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"expenseName\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "294c6d99-9746-45d7-b1eb-fb6c62c66023",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "expense-master",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "e25d1de1-701a-4c8c-b39c-d1876f90a0c2",
+                                    "name": "Update ExpenseMaster",
+                                    "request": {
+                                        "name": "Update ExpenseMaster",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "expense-master",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseName\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "92fd3fa5-fbe7-468c-ab1d-c6102fbcc78c",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "expense-master",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseName\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"expenseName\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "92efe6fa-2300-4e4d-a601-d40b94529379",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "expense-master",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseName\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "2eb30782-6f79-489b-bd18-6c3276bd4d2f",
+                                    "name": "Delete ExpenseMaster",
+                                    "request": {
+                                        "name": "Delete ExpenseMaster",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "expense-master",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "ffc7dc78-1924-437f-99d2-d53059d39d06",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "expense-master",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "0de28c2e-e513-4d5e-9715-5ba9c3a0a7e7",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "expense-master",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "cc1d481e-1d98-4e71-abac-5da8465c00a6",
+                            "name": "List ExpenseMaster",
+                            "request": {
+                                "name": "List ExpenseMaster",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "expense-master"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "197820a8-3b1b-4db7-9cdf-2f8491ad16d2",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "expense-master"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"id\": \"<string>\",\n        \"expenseName\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"id\": \"<string>\",\n        \"expenseName\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "d4cd8742-3e94-4b82-9057-2d8792f9e34b",
+                            "name": "Create ExpenseMaster",
+                            "request": {
+                                "name": "Create ExpenseMaster",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "expense-master"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseName\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "c4eeb30c-6bea-430e-90c8-75c88c921a4f",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "expense-master"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseName\": \"<string>\",\n  \"id\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"id\": \"<string>\",\n    \"expenseName\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "equipment-usage",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "4700646b-6742-4b08-b90d-de21e0268686",
+                                    "name": "Get EquipmentUsage",
+                                    "request": {
+                                        "name": "Get EquipmentUsage",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "equipment-usage",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "fe98c77c-f202-4320-9c92-095dd7747a88",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "equipment-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"equipmentUsageId\": \"<string>\",\n    \"equipmentName\": \"<string>\",\n    \"equipmentType\": \"<string>\",\n    \"startKm\": \"<number>\",\n    \"endKm\": \"<number>\",\n    \"startTime\": \"<dateTime>\",\n    \"endTime\": \"<dateTime>\",\n    \"date\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "ea5c0610-18f5-44dc-986c-23e49c86ba6c",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "equipment-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "264bdcb5-3a04-4f1b-b950-242ab4502152",
+                                    "name": "Update EquipmentUsage",
+                                    "request": {
+                                        "name": "Update EquipmentUsage",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "equipment-usage",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"endKm\": \"<number>\",\n  \"endTime\": \"<dateTime>\",\n  \"equipmentName\": \"<string>\",\n  \"equipmentType\": \"<string>\",\n  \"equipmentUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"startKm\": \"<number>\",\n  \"startTime\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "6825683a-0135-4d72-8b1c-4256b04aa12e",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "equipment-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"endKm\": \"<number>\",\n  \"endTime\": \"<dateTime>\",\n  \"equipmentName\": \"<string>\",\n  \"equipmentType\": \"<string>\",\n  \"equipmentUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"startKm\": \"<number>\",\n  \"startTime\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"equipmentUsageId\": \"<string>\",\n    \"equipmentName\": \"<string>\",\n    \"equipmentType\": \"<string>\",\n    \"startKm\": \"<number>\",\n    \"endKm\": \"<number>\",\n    \"startTime\": \"<dateTime>\",\n    \"endTime\": \"<dateTime>\",\n    \"date\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "92e9fdf2-d4ce-4f80-a010-d637f0c6579e",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "equipment-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"endKm\": \"<number>\",\n  \"endTime\": \"<dateTime>\",\n  \"equipmentName\": \"<string>\",\n  \"equipmentType\": \"<string>\",\n  \"equipmentUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"startKm\": \"<number>\",\n  \"startTime\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "be6ba2a6-bd2c-40ed-bda2-a2e487803661",
+                                    "name": "Delete EquipmentUsage",
+                                    "request": {
+                                        "name": "Delete EquipmentUsage",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "equipment-usage",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "d7391191-7987-481d-99d7-ffe38ec9e10c",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "equipment-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "13af10d3-0424-4fe0-b0b3-4807ac2e7fee",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "equipment-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "d87bad8c-f13c-4ba2-9ec3-cdfa9c68ade7",
+                            "name": "List EquipmentUsage",
+                            "request": {
+                                "name": "List EquipmentUsage",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "equipment-usage"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "974dee6c-3572-4bed-b2c1-5ed8298040ac",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "equipment-usage"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"equipmentUsageId\": \"<string>\",\n        \"equipmentName\": \"<string>\",\n        \"equipmentType\": \"<string>\",\n        \"startKm\": \"<number>\",\n        \"endKm\": \"<number>\",\n        \"startTime\": \"<dateTime>\",\n        \"endTime\": \"<dateTime>\",\n        \"date\": \"<dateTime>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"equipmentUsageId\": \"<string>\",\n        \"equipmentName\": \"<string>\",\n        \"equipmentType\": \"<string>\",\n        \"startKm\": \"<number>\",\n        \"endKm\": \"<number>\",\n        \"startTime\": \"<dateTime>\",\n        \"endTime\": \"<dateTime>\",\n        \"date\": \"<dateTime>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "4f47d606-e8c6-41be-a100-e45dba0d8449",
+                            "name": "Create EquipmentUsage",
+                            "request": {
+                                "name": "Create EquipmentUsage",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "equipment-usage"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"endKm\": \"<number>\",\n  \"endTime\": \"<dateTime>\",\n  \"equipmentName\": \"<string>\",\n  \"equipmentType\": \"<string>\",\n  \"equipmentUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"startKm\": \"<number>\",\n  \"startTime\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "b533284c-1228-4fcd-800b-73561a444699",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "equipment-usage"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"endKm\": \"<number>\",\n  \"endTime\": \"<dateTime>\",\n  \"equipmentName\": \"<string>\",\n  \"equipmentType\": \"<string>\",\n  \"equipmentUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"startKm\": \"<number>\",\n  \"startTime\": \"<dateTime>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"equipmentUsageId\": \"<string>\",\n    \"equipmentName\": \"<string>\",\n    \"equipmentType\": \"<string>\",\n    \"startKm\": \"<number>\",\n    \"endKm\": \"<number>\",\n    \"startTime\": \"<dateTime>\",\n    \"endTime\": \"<dateTime>\",\n    \"date\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "diesel-usage",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "c9f692cc-178c-4f49-857a-e4bd3f40f64e",
+                                    "name": "Get DieselUsage",
+                                    "request": {
+                                        "name": "Get DieselUsage",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "diesel-usage",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "b0503b7f-495a-4245-9512-259a4d019db0",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "diesel-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"dieselUsageId\": \"<string>\",\n    \"vehicleName\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"liters\": \"<number>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "f71b8a1a-9582-439d-84e3-ac09d31f70c4",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "diesel-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "cd9bde68-071a-4258-9811-e5715a45cc2f",
+                                    "name": "Update DieselUsage",
+                                    "request": {
+                                        "name": "Update DieselUsage",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "diesel-usage",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"dieselUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"liters\": \"<number>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "1162751b-5c8d-4c2e-b51e-aefcbd210936",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "diesel-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"dieselUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"liters\": \"<number>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"dieselUsageId\": \"<string>\",\n    \"vehicleName\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"liters\": \"<number>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "38dd3d8c-4206-4041-9d61-ca8479670562",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "diesel-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"dieselUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"liters\": \"<number>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "115c0a11-3698-4506-9b97-7836dbcef293",
+                                    "name": "Delete DieselUsage",
+                                    "request": {
+                                        "name": "Delete DieselUsage",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "diesel-usage",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "dd2a7b2e-25fb-4e93-bc72-ea08cacfd198",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "diesel-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "760b87de-aeef-4c2b-a062-f7313364afab",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "diesel-usage",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "4ab6028c-62ad-456c-b3d6-dd5348304f86",
+                            "name": "List DieselUsage",
+                            "request": {
+                                "name": "List DieselUsage",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "diesel-usage"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "0032fa23-c54a-412e-bb16-958c2dd1209b",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "diesel-usage"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"dieselUsageId\": \"<string>\",\n        \"vehicleName\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"liters\": \"<number>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"dieselUsageId\": \"<string>\",\n        \"vehicleName\": \"<string>\",\n        \"date\": \"<dateTime>\",\n        \"liters\": \"<number>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "4001aec8-cedd-412d-8330-46835db49559",
+                            "name": "Create DieselUsage",
+                            "request": {
+                                "name": "Create DieselUsage",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "diesel-usage"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"dieselUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"liters\": \"<number>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "565c140a-eca6-45e2-81c3-72c5b2eca045",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "diesel-usage"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"date\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"dieselUsageId\": \"<string>\",\n  \"isSynced\": \"<boolean>\",\n  \"liters\": \"<number>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"vehicleName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"dieselUsageId\": \"<string>\",\n    \"vehicleName\": \"<string>\",\n    \"date\": \"<dateTime>\",\n    \"liters\": \"<number>\",\n    \"companyUuid\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "daily-expenses",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "9e963ca4-6bf1-4453-8727-374957a1eddb",
+                                    "name": "Get DailyExpense",
+                                    "request": {
+                                        "name": "Get DailyExpense",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "daily-expenses",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "27d2cb7e-08a2-41dc-92df-d6153e072bb8",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "daily-expenses",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"expenseId\": \"<string>\",\n    \"expenseType\": \"<string>\",\n    \"expenseAmount\": \"<number>\",\n    \"expenseDate\": \"<dateTime>\",\n    \"expenseNote\": \"<string>\",\n    \"isPaid\": \"<boolean>\",\n    \"paidBy\": \"<string>\",\n    \"paidTo\": \"<string>\",\n    \"paidDate\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "47277137-b35b-4adb-8d2b-33b729e3ef51",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "daily-expenses",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "f930b4ae-3a1a-4ec1-b53f-0b3c586a3247",
+                                    "name": "Update DailyExpense",
+                                    "request": {
+                                        "name": "Update DailyExpense",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "daily-expenses",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseAmount\": \"<number>\",\n  \"expenseDate\": \"<dateTime>\",\n  \"expenseId\": \"<string>\",\n  \"expenseType\": \"<string>\",\n  \"isPaid\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"expenseNote\": \"<string>\",\n  \"paidBy\": \"<string>\",\n  \"paidTo\": \"<string>\",\n  \"paidDate\": \"<dateTime>\",\n  \"userId\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "40c05495-7848-4a3b-b1da-d503e4067cb7",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "daily-expenses",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseAmount\": \"<number>\",\n  \"expenseDate\": \"<dateTime>\",\n  \"expenseId\": \"<string>\",\n  \"expenseType\": \"<string>\",\n  \"isPaid\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"expenseNote\": \"<string>\",\n  \"paidBy\": \"<string>\",\n  \"paidTo\": \"<string>\",\n  \"paidDate\": \"<dateTime>\",\n  \"userId\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"expenseId\": \"<string>\",\n    \"expenseType\": \"<string>\",\n    \"expenseAmount\": \"<number>\",\n    \"expenseDate\": \"<dateTime>\",\n    \"expenseNote\": \"<string>\",\n    \"isPaid\": \"<boolean>\",\n    \"paidBy\": \"<string>\",\n    \"paidTo\": \"<string>\",\n    \"paidDate\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "74a42b47-1b78-4566-81dc-800968a37aa3",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "daily-expenses",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseAmount\": \"<number>\",\n  \"expenseDate\": \"<dateTime>\",\n  \"expenseId\": \"<string>\",\n  \"expenseType\": \"<string>\",\n  \"isPaid\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"expenseNote\": \"<string>\",\n  \"paidBy\": \"<string>\",\n  \"paidTo\": \"<string>\",\n  \"paidDate\": \"<dateTime>\",\n  \"userId\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "5db7c81f-9674-475c-b5a3-104e4f0673d5",
+                                    "name": "Delete DailyExpense",
+                                    "request": {
+                                        "name": "Delete DailyExpense",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "daily-expenses",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "4d967174-492b-4fa2-b0e8-293c2a6e50e9",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "daily-expenses",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "6e790e3f-61a0-4782-beb9-1551a15e9e57",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "daily-expenses",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "52d98c8a-bdc5-40db-99c7-78599ef3dd46",
+                            "name": "List DailyExpense",
+                            "request": {
+                                "name": "List DailyExpense",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "daily-expenses"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "dateFrom",
+                                            "value": "<dateTime>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "dateTo",
+                                            "value": "<dateTime>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "e33f9e14-3385-4210-886f-6182e13905d1",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "daily-expenses"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "dateFrom",
+                                                    "value": "<dateTime>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "dateTo",
+                                                    "value": "<dateTime>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"expenseId\": \"<string>\",\n        \"expenseType\": \"<string>\",\n        \"expenseAmount\": \"<number>\",\n        \"expenseDate\": \"<dateTime>\",\n        \"expenseNote\": \"<string>\",\n        \"isPaid\": \"<boolean>\",\n        \"paidBy\": \"<string>\",\n        \"paidTo\": \"<string>\",\n        \"paidDate\": \"<dateTime>\",\n        \"companyUuid\": \"<string>\",\n        \"userId\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"expenseId\": \"<string>\",\n        \"expenseType\": \"<string>\",\n        \"expenseAmount\": \"<number>\",\n        \"expenseDate\": \"<dateTime>\",\n        \"expenseNote\": \"<string>\",\n        \"isPaid\": \"<boolean>\",\n        \"paidBy\": \"<string>\",\n        \"paidTo\": \"<string>\",\n        \"paidDate\": \"<dateTime>\",\n        \"companyUuid\": \"<string>\",\n        \"userId\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "7a90ed66-169c-44af-bb32-0f571bd62846",
+                            "name": "Create DailyExpense",
+                            "request": {
+                                "name": "Create DailyExpense",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "daily-expenses"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseAmount\": \"<number>\",\n  \"expenseDate\": \"<dateTime>\",\n  \"expenseId\": \"<string>\",\n  \"expenseType\": \"<string>\",\n  \"isPaid\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"expenseNote\": \"<string>\",\n  \"paidBy\": \"<string>\",\n  \"paidTo\": \"<string>\",\n  \"paidDate\": \"<dateTime>\",\n  \"userId\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "0e9dcca4-b204-4c77-a1a7-120ea0756720",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "daily-expenses"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyUuid\": \"<string>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"expenseAmount\": \"<number>\",\n  \"expenseDate\": \"<dateTime>\",\n  \"expenseId\": \"<string>\",\n  \"expenseType\": \"<string>\",\n  \"isPaid\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"expenseNote\": \"<string>\",\n  \"paidBy\": \"<string>\",\n  \"paidTo\": \"<string>\",\n  \"paidDate\": \"<dateTime>\",\n  \"userId\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"expenseId\": \"<string>\",\n    \"expenseType\": \"<string>\",\n    \"expenseAmount\": \"<number>\",\n    \"expenseDate\": \"<dateTime>\",\n    \"expenseNote\": \"<string>\",\n    \"isPaid\": \"<boolean>\",\n    \"paidBy\": \"<string>\",\n    \"paidTo\": \"<string>\",\n    \"paidDate\": \"<dateTime>\",\n    \"companyUuid\": \"<string>\",\n    \"userId\": \"<string>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "companies",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{id}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "19b8ab04-b4d6-47ba-8ddd-257297e44388",
+                                    "name": "Get Company",
+                                    "request": {
+                                        "name": "Get Company",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "companies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "c4002910-b09f-483a-8e03-de08937b751d",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "companies",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"uuid\": \"<string>\",\n    \"companyCode\": \"<string>\",\n    \"companyName\": \"<string>\",\n    \"companyContactNo\": \"<string>\",\n    \"companyCoordinates\": \"<string>\",\n    \"companyLocation\": \"<string>\",\n    \"companyRegistrationDate\": \"<date>\",\n    \"ownerName\": \"<string>\",\n    \"ownerMobileNo\": \"<string>\",\n    \"ownerEmailAddress\": \"<string>\",\n    \"ownerDob\": \"<date>\",\n    \"isActive\": \"<boolean>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "96688bda-8eec-4095-abb5-07c761dd879e",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "companies",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "ce333559-cc2e-4029-83e7-910fd728a787",
+                                    "name": "Update Company",
+                                    "request": {
+                                        "name": "Update Company",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "companies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "PUT",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyCode\": \"<string>\",\n  \"companyContactNo\": \"<string>\",\n  \"companyLocation\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"companyRegistrationDate\": \"<date>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"ownerDob\": \"<date>\",\n  \"ownerEmailAddress\": \"<string>\",\n  \"ownerMobileNo\": \"<string>\",\n  \"ownerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"uuid\": \"<string>\",\n  \"companyCoordinates\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        },
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "4a4b29a1-52e4-496b-93f4-d1af5b2f9913",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "companies",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyCode\": \"<string>\",\n  \"companyContactNo\": \"<string>\",\n  \"companyLocation\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"companyRegistrationDate\": \"<date>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"ownerDob\": \"<date>\",\n  \"ownerEmailAddress\": \"<string>\",\n  \"ownerMobileNo\": \"<string>\",\n  \"ownerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"uuid\": \"<string>\",\n  \"companyCoordinates\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"uuid\": \"<string>\",\n    \"companyCode\": \"<string>\",\n    \"companyName\": \"<string>\",\n    \"companyContactNo\": \"<string>\",\n    \"companyCoordinates\": \"<string>\",\n    \"companyLocation\": \"<string>\",\n    \"companyRegistrationDate\": \"<date>\",\n    \"ownerName\": \"<string>\",\n    \"ownerMobileNo\": \"<string>\",\n    \"ownerEmailAddress\": \"<string>\",\n    \"ownerDob\": \"<date>\",\n    \"isActive\": \"<boolean>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "0a72b9b3-b7fe-410b-b923-7548cb0370c9",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "companies",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "PUT",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"companyCode\": \"<string>\",\n  \"companyContactNo\": \"<string>\",\n  \"companyLocation\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"companyRegistrationDate\": \"<date>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"ownerDob\": \"<date>\",\n  \"ownerEmailAddress\": \"<string>\",\n  \"ownerMobileNo\": \"<string>\",\n  \"ownerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"uuid\": \"<string>\",\n  \"companyCoordinates\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                },
+                                {
+                                    "id": "ebc7ac17-35d3-45b3-a908-4a7cccf1c26e",
+                                    "name": "Delete Company",
+                                    "request": {
+                                        "name": "Delete Company",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "companies",
+                                                ":id"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "id",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "DELETE",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "275219b1-86de-415b-a091-3de21af96493",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "companies",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "333953c4-34f7-4be7-8dc8-d2e8b3c7ae02",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "companies",
+                                                        ":id"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "edbd5819-0406-4fbc-924e-420a9f431a2d",
+                            "name": "List Company",
+                            "request": {
+                                "name": "List Company",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "companies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "4c052432-5098-48a7-8d80-a78b4e2a17ad",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "companies"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"uuid\": \"<string>\",\n        \"companyCode\": \"<string>\",\n        \"companyName\": \"<string>\",\n        \"companyContactNo\": \"<string>\",\n        \"companyCoordinates\": \"<string>\",\n        \"companyLocation\": \"<string>\",\n        \"companyRegistrationDate\": \"<date>\",\n        \"ownerName\": \"<string>\",\n        \"ownerMobileNo\": \"<string>\",\n        \"ownerEmailAddress\": \"<string>\",\n        \"ownerDob\": \"<date>\",\n        \"isActive\": \"<boolean>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"uuid\": \"<string>\",\n        \"companyCode\": \"<string>\",\n        \"companyName\": \"<string>\",\n        \"companyContactNo\": \"<string>\",\n        \"companyCoordinates\": \"<string>\",\n        \"companyLocation\": \"<string>\",\n        \"companyRegistrationDate\": \"<date>\",\n        \"ownerName\": \"<string>\",\n        \"ownerMobileNo\": \"<string>\",\n        \"ownerEmailAddress\": \"<string>\",\n        \"ownerDob\": \"<date>\",\n        \"isActive\": \"<boolean>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "id": "67c424db-1f55-4e8e-810e-819044afcc11",
+                            "name": "Create Company",
+                            "request": {
+                                "name": "Create Company",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "companies"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companyCode\": \"<string>\",\n  \"companyContactNo\": \"<string>\",\n  \"companyLocation\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"companyRegistrationDate\": \"<date>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"ownerDob\": \"<date>\",\n  \"ownerEmailAddress\": \"<string>\",\n  \"ownerMobileNo\": \"<string>\",\n  \"ownerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"uuid\": \"<string>\",\n  \"companyCoordinates\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "65c06757-823f-46bb-8e7f-1fc80a118af4",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "companies"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companyCode\": \"<string>\",\n  \"companyContactNo\": \"<string>\",\n  \"companyLocation\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"companyRegistrationDate\": \"<date>\",\n  \"createdAt\": \"<dateTime>\",\n  \"deleted\": \"<boolean>\",\n  \"isActive\": \"<boolean>\",\n  \"isSynced\": \"<boolean>\",\n  \"ownerDob\": \"<date>\",\n  \"ownerEmailAddress\": \"<string>\",\n  \"ownerMobileNo\": \"<string>\",\n  \"ownerName\": \"<string>\",\n  \"updatedAt\": \"<dateTime>\",\n  \"uuid\": \"<string>\",\n  \"companyCoordinates\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"updatedBy\": \"<string>\",\n  \"deletedAt\": \"<dateTime>\",\n  \"changeId\": \"<long>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"uuid\": \"<string>\",\n    \"companyCode\": \"<string>\",\n    \"companyName\": \"<string>\",\n    \"companyContactNo\": \"<string>\",\n    \"companyCoordinates\": \"<string>\",\n    \"companyLocation\": \"<string>\",\n    \"companyRegistrationDate\": \"<date>\",\n    \"ownerName\": \"<string>\",\n    \"ownerMobileNo\": \"<string>\",\n    \"ownerEmailAddress\": \"<string>\",\n    \"ownerDob\": \"<date>\",\n    \"isActive\": \"<boolean>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "vehicle-entries-ops",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{entryId}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "name": "payment",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "68db58f2-0e87-4157-a55d-8cea4be41f85",
+                                            "name": "Add a payment towards a vehicle entry",
+                                            "request": {
+                                                "name": "Add a payment towards a vehicle entry",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries-ops",
+                                                        ":entryId",
+                                                        "payment"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "entryId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"receivedBy\": \"<string>\",\n  \"when\": \"<dateTime>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                },
+                                                "auth": {
+                                                    "type": "bearer",
+                                                    "bearer": [
+                                                        {
+                                                            "key": "token",
+                                                            "value": "{{bearerToken}}"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "f7defed1-72d4-47e0-8802-711210e5359b",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "vehicle-entries-ops",
+                                                                ":entryId",
+                                                                "payment"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                            },
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "POST",
+                                                        "body": {
+                                                            "mode": "raw",
+                                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"receivedBy\": \"<string>\",\n  \"when\": \"<dateTime>\"\n}",
+                                                            "options": {
+                                                                "raw": {
+                                                                    "headerFamily": "json",
+                                                                    "language": "json"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"entryId\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"vehicleNumber\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"fromAddress\": \"<string>\",\n    \"toAddress\": \"<string>\",\n    \"driverName\": \"<string>\",\n    \"driverContactNo\": \"<string>\",\n    \"commission\": \"<number>\",\n    \"beta\": \"<number>\",\n    \"referredBy\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"paytype\": \"<string>\",\n    \"entryDate\": \"<date>\",\n    \"entryTime\": \"<dateTime>\",\n    \"exitTime\": \"<dateTime>\",\n    \"notes\": \"<string>\",\n    \"paymentReceivedBy\": \"<string>\",\n    \"paidAmount\": \"<number>\",\n    \"pendingAmt\": \"<number>\",\n    \"isSettled\": \"<boolean>\",\n    \"settlementType\": \"<string>\",\n    \"settlementDate\": \"<dateTime>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "6fff4c74-8e58-4f8c-915e-9e4b758402bd",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "vehicle-entries-ops",
+                                                                ":entryId",
+                                                                "payment"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "POST",
+                                                        "body": {
+                                                            "mode": "raw",
+                                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"receivedBy\": \"<string>\",\n  \"when\": \"<dateTime>\"\n}",
+                                                            "options": {
+                                                                "raw": {
+                                                                    "headerFamily": "json",
+                                                                    "language": "json"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "exit",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "db04d94d-4814-4380-aa51-f41afb5e1cd7",
+                                            "name": "Mark vehicle exit time",
+                                            "request": {
+                                                "name": "Mark vehicle exit time",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "vehicle-entries-ops",
+                                                        ":entryId",
+                                                        "exit"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "when",
+                                                            "value": "<dateTime>"
+                                                        }
+                                                    ],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "entryId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {},
+                                                "auth": {
+                                                    "type": "bearer",
+                                                    "bearer": [
+                                                        {
+                                                            "key": "token",
+                                                            "value": "{{bearerToken}}"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "2a9d8296-d748-427d-83ed-094840526781",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "vehicle-entries-ops",
+                                                                ":entryId",
+                                                                "exit"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "key": "when",
+                                                                    "value": "<dateTime>"
+                                                                }
+                                                            ],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "POST",
+                                                        "body": {}
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"entryId\": \"<string>\",\n    \"companyUuid\": \"<string>\",\n    \"payerId\": \"<string>\",\n    \"vehicleNumber\": \"<string>\",\n    \"vehicleType\": \"<string>\",\n    \"fromAddress\": \"<string>\",\n    \"toAddress\": \"<string>\",\n    \"driverName\": \"<string>\",\n    \"driverContactNo\": \"<string>\",\n    \"commission\": \"<number>\",\n    \"beta\": \"<number>\",\n    \"referredBy\": \"<string>\",\n    \"amount\": \"<number>\",\n    \"paytype\": \"<string>\",\n    \"entryDate\": \"<date>\",\n    \"entryTime\": \"<dateTime>\",\n    \"exitTime\": \"<dateTime>\",\n    \"notes\": \"<string>\",\n    \"paymentReceivedBy\": \"<string>\",\n    \"paidAmount\": \"<number>\",\n    \"pendingAmt\": \"<number>\",\n    \"isSettled\": \"<boolean>\",\n    \"settlementType\": \"<string>\",\n    \"settlementDate\": \"<dateTime>\",\n    \"isSynced\": \"<boolean>\",\n    \"createdBy\": \"<string>\",\n    \"createdAt\": \"<dateTime>\",\n    \"updatedBy\": \"<string>\",\n    \"updatedAt\": \"<dateTime>\",\n    \"deleted\": \"<boolean>\",\n    \"deletedAt\": \"<dateTime>\",\n    \"changeId\": \"<long>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "16ffe306-527f-47af-847b-c468afe0f386",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "vehicle-entries-ops",
+                                                                ":entryId",
+                                                                "exit"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [
+                                                                {
+                                                                    "disabled": false,
+                                                                    "description": {
+                                                                        "content": "",
+                                                                        "type": "text/plain"
+                                                                    },
+                                                                    "key": "when",
+                                                                    "value": "<dateTime>"
+                                                                }
+                                                            ],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "POST",
+                                                        "body": {}
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "sync",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "66e63933-0ba8-4edb-9527-e1797dc12bf7",
+                            "name": "Bulk synchronize entities",
+                            "request": {
+                                "name": "Bulk synchronize entities",
+                                "description": {
+                                    "content": "Accepts lists of entity DTOs and persists them with isSynced=true",
+                                    "type": "text/plain"
+                                },
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "sync"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"companies\": [\n    {\n      \"companyCode\": \"<string>\",\n      \"companyContactNo\": \"<string>\",\n      \"companyLocation\": \"<string>\",\n      \"companyName\": \"<string>\",\n      \"companyRegistrationDate\": \"<date>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"ownerDob\": \"<date>\",\n      \"ownerEmailAddress\": \"<string>\",\n      \"ownerMobileNo\": \"<string>\",\n      \"ownerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"uuid\": \"<string>\",\n      \"companyCoordinates\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyCode\": \"<string>\",\n      \"companyContactNo\": \"<string>\",\n      \"companyLocation\": \"<string>\",\n      \"companyName\": \"<string>\",\n      \"companyRegistrationDate\": \"<date>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"ownerDob\": \"<date>\",\n      \"ownerEmailAddress\": \"<string>\",\n      \"ownerMobileNo\": \"<string>\",\n      \"ownerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"uuid\": \"<string>\",\n      \"companyCoordinates\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"dailyExpenses\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseAmount\": \"<number>\",\n      \"expenseDate\": \"<dateTime>\",\n      \"expenseId\": \"<string>\",\n      \"expenseType\": \"<string>\",\n      \"isPaid\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"expenseNote\": \"<string>\",\n      \"paidBy\": \"<string>\",\n      \"paidTo\": \"<string>\",\n      \"paidDate\": \"<dateTime>\",\n      \"userId\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseAmount\": \"<number>\",\n      \"expenseDate\": \"<dateTime>\",\n      \"expenseId\": \"<string>\",\n      \"expenseType\": \"<string>\",\n      \"isPaid\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"expenseNote\": \"<string>\",\n      \"paidBy\": \"<string>\",\n      \"paidTo\": \"<string>\",\n      \"paidDate\": \"<dateTime>\",\n      \"userId\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"dieselUsages\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"dieselUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"liters\": \"<number>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleName\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"dieselUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"liters\": \"<number>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleName\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"equipmentUsages\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"endKm\": \"<number>\",\n      \"endTime\": \"<dateTime>\",\n      \"equipmentName\": \"<string>\",\n      \"equipmentType\": \"<string>\",\n      \"equipmentUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"startKm\": \"<number>\",\n      \"startTime\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"endKm\": \"<number>\",\n      \"endTime\": \"<dateTime>\",\n      \"equipmentName\": \"<string>\",\n      \"equipmentType\": \"<string>\",\n      \"equipmentUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"startKm\": \"<number>\",\n      \"startTime\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"expenseMasters\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseName\": \"<string>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseName\": \"<string>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"internalVehicles\": [\n    {\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleId\": \"<string>\",\n      \"vehicleName\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"companyUuid\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleId\": \"<string>\",\n      \"vehicleName\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"companyUuid\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"payers\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"mobileNo\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"payerAddress\": \"<string>\",\n      \"registrationDate\": \"<date>\",\n      \"creditLimit\": \"<integer>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"mobileNo\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"payerAddress\": \"<string>\",\n      \"registrationDate\": \"<date>\",\n      \"creditLimit\": \"<integer>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"payerSettlements\": [\n    {\n      \"amount\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"payerId\": \"<string>\",\n      \"settlementId\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"amount\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"payerId\": \"<string>\",\n      \"settlementId\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"vehicleEntries\": [\n    {\n      \"amount\": \"<number>\",\n      \"beta\": \"<number>\",\n      \"commission\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"driverContactNo\": \"<string>\",\n      \"driverName\": \"<string>\",\n      \"entryDate\": \"<date>\",\n      \"entryId\": \"<string>\",\n      \"entryTime\": \"<dateTime>\",\n      \"fromAddress\": \"<string>\",\n      \"isSettled\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"paidAmount\": \"<number>\",\n      \"payerId\": \"<string>\",\n      \"paytype\": \"<string>\",\n      \"pendingAmt\": \"<number>\",\n      \"toAddress\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleNumber\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"referredBy\": \"<string>\",\n      \"exitTime\": \"<dateTime>\",\n      \"notes\": \"<string>\",\n      \"paymentReceivedBy\": \"<string>\",\n      \"settlementType\": \"<string>\",\n      \"settlementDate\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"amount\": \"<number>\",\n      \"beta\": \"<number>\",\n      \"commission\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"driverContactNo\": \"<string>\",\n      \"driverName\": \"<string>\",\n      \"entryDate\": \"<date>\",\n      \"entryId\": \"<string>\",\n      \"entryTime\": \"<dateTime>\",\n      \"fromAddress\": \"<string>\",\n      \"isSettled\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"paidAmount\": \"<number>\",\n      \"payerId\": \"<string>\",\n      \"paytype\": \"<string>\",\n      \"pendingAmt\": \"<number>\",\n      \"toAddress\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleNumber\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"referredBy\": \"<string>\",\n      \"exitTime\": \"<dateTime>\",\n      \"notes\": \"<string>\",\n      \"paymentReceivedBy\": \"<string>\",\n      \"settlementType\": \"<string>\",\n      \"settlementDate\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"vehicleTypes\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"type\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleType\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"type\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleType\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ]\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "7020dd22-8f91-40d1-b000-5c41651c9591",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "sync"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"companies\": [\n    {\n      \"companyCode\": \"<string>\",\n      \"companyContactNo\": \"<string>\",\n      \"companyLocation\": \"<string>\",\n      \"companyName\": \"<string>\",\n      \"companyRegistrationDate\": \"<date>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"ownerDob\": \"<date>\",\n      \"ownerEmailAddress\": \"<string>\",\n      \"ownerMobileNo\": \"<string>\",\n      \"ownerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"uuid\": \"<string>\",\n      \"companyCoordinates\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyCode\": \"<string>\",\n      \"companyContactNo\": \"<string>\",\n      \"companyLocation\": \"<string>\",\n      \"companyName\": \"<string>\",\n      \"companyRegistrationDate\": \"<date>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"ownerDob\": \"<date>\",\n      \"ownerEmailAddress\": \"<string>\",\n      \"ownerMobileNo\": \"<string>\",\n      \"ownerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"uuid\": \"<string>\",\n      \"companyCoordinates\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"dailyExpenses\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseAmount\": \"<number>\",\n      \"expenseDate\": \"<dateTime>\",\n      \"expenseId\": \"<string>\",\n      \"expenseType\": \"<string>\",\n      \"isPaid\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"expenseNote\": \"<string>\",\n      \"paidBy\": \"<string>\",\n      \"paidTo\": \"<string>\",\n      \"paidDate\": \"<dateTime>\",\n      \"userId\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseAmount\": \"<number>\",\n      \"expenseDate\": \"<dateTime>\",\n      \"expenseId\": \"<string>\",\n      \"expenseType\": \"<string>\",\n      \"isPaid\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"expenseNote\": \"<string>\",\n      \"paidBy\": \"<string>\",\n      \"paidTo\": \"<string>\",\n      \"paidDate\": \"<dateTime>\",\n      \"userId\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"dieselUsages\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"dieselUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"liters\": \"<number>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleName\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"dieselUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"liters\": \"<number>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleName\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"equipmentUsages\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"endKm\": \"<number>\",\n      \"endTime\": \"<dateTime>\",\n      \"equipmentName\": \"<string>\",\n      \"equipmentType\": \"<string>\",\n      \"equipmentUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"startKm\": \"<number>\",\n      \"startTime\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"endKm\": \"<number>\",\n      \"endTime\": \"<dateTime>\",\n      \"equipmentName\": \"<string>\",\n      \"equipmentType\": \"<string>\",\n      \"equipmentUsageId\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"startKm\": \"<number>\",\n      \"startTime\": \"<dateTime>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"expenseMasters\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseName\": \"<string>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"expenseName\": \"<string>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"internalVehicles\": [\n    {\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleId\": \"<string>\",\n      \"vehicleName\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"companyUuid\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isActive\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleId\": \"<string>\",\n      \"vehicleName\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"companyUuid\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"payers\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"mobileNo\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"payerAddress\": \"<string>\",\n      \"registrationDate\": \"<date>\",\n      \"creditLimit\": \"<integer>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"mobileNo\": \"<string>\",\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"payerAddress\": \"<string>\",\n      \"registrationDate\": \"<date>\",\n      \"creditLimit\": \"<integer>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"payerSettlements\": [\n    {\n      \"amount\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"payerId\": \"<string>\",\n      \"settlementId\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"amount\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"date\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"payerId\": \"<string>\",\n      \"settlementId\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"vehicleEntries\": [\n    {\n      \"amount\": \"<number>\",\n      \"beta\": \"<number>\",\n      \"commission\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"driverContactNo\": \"<string>\",\n      \"driverName\": \"<string>\",\n      \"entryDate\": \"<date>\",\n      \"entryId\": \"<string>\",\n      \"entryTime\": \"<dateTime>\",\n      \"fromAddress\": \"<string>\",\n      \"isSettled\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"paidAmount\": \"<number>\",\n      \"payerId\": \"<string>\",\n      \"paytype\": \"<string>\",\n      \"pendingAmt\": \"<number>\",\n      \"toAddress\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleNumber\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"referredBy\": \"<string>\",\n      \"exitTime\": \"<dateTime>\",\n      \"notes\": \"<string>\",\n      \"paymentReceivedBy\": \"<string>\",\n      \"settlementType\": \"<string>\",\n      \"settlementDate\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"amount\": \"<number>\",\n      \"beta\": \"<number>\",\n      \"commission\": \"<number>\",\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"driverContactNo\": \"<string>\",\n      \"driverName\": \"<string>\",\n      \"entryDate\": \"<date>\",\n      \"entryId\": \"<string>\",\n      \"entryTime\": \"<dateTime>\",\n      \"fromAddress\": \"<string>\",\n      \"isSettled\": \"<boolean>\",\n      \"isSynced\": \"<boolean>\",\n      \"paidAmount\": \"<number>\",\n      \"payerId\": \"<string>\",\n      \"paytype\": \"<string>\",\n      \"pendingAmt\": \"<number>\",\n      \"toAddress\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleNumber\": \"<string>\",\n      \"vehicleType\": \"<string>\",\n      \"referredBy\": \"<string>\",\n      \"exitTime\": \"<dateTime>\",\n      \"notes\": \"<string>\",\n      \"paymentReceivedBy\": \"<string>\",\n      \"settlementType\": \"<string>\",\n      \"settlementDate\": \"<dateTime>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ],\n  \"vehicleTypes\": [\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"type\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleType\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    },\n    {\n      \"companyUuid\": \"<string>\",\n      \"createdAt\": \"<dateTime>\",\n      \"deleted\": \"<boolean>\",\n      \"id\": \"<string>\",\n      \"isSynced\": \"<boolean>\",\n      \"type\": \"<string>\",\n      \"updatedAt\": \"<dateTime>\",\n      \"vehicleType\": \"<string>\",\n      \"createdBy\": \"<string>\",\n      \"updatedBy\": \"<string>\",\n      \"deletedAt\": \"<dateTime>\",\n      \"changeId\": \"<long>\"\n    }\n  ]\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"companies\": \"<integer>\",\n    \"dailyExpenses\": \"<integer>\",\n    \"dieselUsages\": \"<integer>\",\n    \"equipmentUsages\": \"<integer>\",\n    \"expenseMasters\": \"<integer>\",\n    \"internalVehicles\": \"<integer>\",\n    \"payers\": \"<integer>\",\n    \"payerSettlements\": \"<integer>\",\n    \"vehicleEntries\": \"<integer>\",\n    \"vehicleTypes\": \"<integer>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "name": "download",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "edeff2db-37b3-4ed0-85fa-4d3565983c0b",
+                                    "name": "Download changed entities",
+                                    "request": {
+                                        "name": "Download changed entities",
+                                        "description": {
+                                            "content": "Returns entity deltas since a cursor",
+                                            "type": "text/plain"
+                                        },
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "sync",
+                                                "download"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sinceCursor",
+                                                    "value": "<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "entities",
+                                                    "value": "<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "entities",
+                                                    "value": "<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "limit",
+                                                    "value": "<integer>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "0644a69a-e0de-4665-ae1a-51917a6cd7c8",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "sync",
+                                                        "download"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "sinceCursor",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "entities",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "limit",
+                                                            "value": "<integer>"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"key_0\": {}\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "receipts",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "pdf",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "c31638c7-7333-44e6-aad2-c211e8fc394a",
+                                    "name": "build Pdf",
+                                    "request": {
+                                        "name": "build Pdf",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "receipts",
+                                                "pdf"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "multipart/form-data"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "formdata",
+                                            "formdata": [
+                                                {
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "data",
+                                                    "value": "<string>",
+                                                    "type": "text"
+                                                },
+                                                {
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "qrPng",
+                                                    "type": "file"
+                                                },
+                                                {
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "qrUrl",
+                                                    "value": "<string>",
+                                                    "type": "text"
+                                                }
+                                            ]
+                                        },
+                                        "auth": null
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "f14a3783-5bee-447e-a9fc-5976cf205a77",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "receipts",
+                                                        "pdf"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "multipart/form-data"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "formdata",
+                                                    "formdata": [
+                                                        {
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "data",
+                                                            "value": "<string>",
+                                                            "type": "text"
+                                                        },
+                                                        {
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "qrPng",
+                                                            "type": "file"
+                                                        },
+                                                        {
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "qrUrl",
+                                                            "value": "<string>",
+                                                            "type": "text"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "order",
+                            "description": "",
+                            "item": [
+                                {
+                                    "name": "{orderId}",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "8e6f9183-c485-4091-b60a-4cf897a0cae3",
+                                            "name": "find By Order Id",
+                                            "request": {
+                                                "name": "find By Order Id",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "receipts",
+                                                        "order",
+                                                        ":orderId"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "orderId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {},
+                                                "auth": null
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "49a23634-4ecb-46e1-82bd-f031317df1ec",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "receipts",
+                                                                "order",
+                                                                ":orderId"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "GET",
+                                                        "body": {}
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "cef9d0a0-72a4-45c2-8780-a3fa0426b8bf",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "receipts",
+                                                                "order",
+                                                                ":orderId"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "GET",
+                                                        "body": {}
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "ledger",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "{payerId}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "name": "apply-payment",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "6f04b734-7b68-46d7-8b88-b850d001c816",
+                                            "name": "Apply payment to payer ledger",
+                                            "request": {
+                                                "name": "Apply payment to payer ledger",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "ledger",
+                                                        ":payerId",
+                                                        "apply-payment"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "payerId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Content-Type",
+                                                        "value": "application/json"
+                                                    },
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "POST",
+                                                "body": {
+                                                    "mode": "raw",
+                                                    "raw": "{\n  \"amount\": \"<number>\",\n  \"settlementType\": \"<string>\"\n}",
+                                                    "options": {
+                                                        "raw": {
+                                                            "headerFamily": "json",
+                                                            "language": "json"
+                                                        }
+                                                    }
+                                                },
+                                                "auth": {
+                                                    "type": "bearer",
+                                                    "bearer": [
+                                                        {
+                                                            "key": "token",
+                                                            "value": "{{bearerToken}}"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "23204c38-b78f-486e-ac42-84970052c374",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "ledger",
+                                                                ":payerId",
+                                                                "apply-payment"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                            },
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "POST",
+                                                        "body": {
+                                                            "mode": "raw",
+                                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"settlementType\": \"<string>\"\n}",
+                                                            "options": {
+                                                                "raw": {
+                                                                    "headerFamily": "json",
+                                                                    "language": "json"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "c312a254-2469-42b7-8172-17066b696525",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "ledger",
+                                                                ":payerId",
+                                                                "apply-payment"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Content-Type",
+                                                                "value": "application/json"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "POST",
+                                                        "body": {
+                                                            "mode": "raw",
+                                                            "raw": "{\n  \"amount\": \"<number>\",\n  \"settlementType\": \"<string>\"\n}",
+                                                            "options": {
+                                                                "raw": {
+                                                                    "headerFamily": "json",
+                                                                    "language": "json"
+                                                                }
+                                                            }
+                                                        }
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "id": "add8cf28-2fb5-4479-adc3-2e57f9cc7fd0",
+                                    "name": "Get ledger for payer",
+                                    "request": {
+                                        "name": "Get ledger for payer",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "ledger",
+                                                ":payerId"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": [
+                                                {
+                                                    "type": "any",
+                                                    "value": "<string>",
+                                                    "key": "payerId",
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "5f349537-61c0-47e8-94d0-a65d3ad2b710",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "ledger",
+                                                        ":payerId"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "page",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "size",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "sort",
+                                                            "value": "<string>,<string>"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"entryId\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"vehicleNumber\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"fromAddress\": \"<string>\",\n        \"toAddress\": \"<string>\",\n        \"driverName\": \"<string>\",\n        \"driverContactNo\": \"<string>\",\n        \"commission\": \"<number>\",\n        \"beta\": \"<number>\",\n        \"referredBy\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"paytype\": \"<string>\",\n        \"entryDate\": \"<date>\",\n        \"entryTime\": \"<dateTime>\",\n        \"exitTime\": \"<dateTime>\",\n        \"notes\": \"<string>\",\n        \"paymentReceivedBy\": \"<string>\",\n        \"paidAmount\": \"<number>\",\n        \"pendingAmt\": \"<number>\",\n        \"isSettled\": \"<boolean>\",\n        \"settlementType\": \"<string>\",\n        \"settlementDate\": \"<dateTime>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"entryId\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"vehicleNumber\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"fromAddress\": \"<string>\",\n        \"toAddress\": \"<string>\",\n        \"driverName\": \"<string>\",\n        \"driverContactNo\": \"<string>\",\n        \"commission\": \"<number>\",\n        \"beta\": \"<number>\",\n        \"referredBy\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"paytype\": \"<string>\",\n        \"entryDate\": \"<date>\",\n        \"entryTime\": \"<dateTime>\",\n        \"exitTime\": \"<dateTime>\",\n        \"notes\": \"<string>\",\n        \"paymentReceivedBy\": \"<string>\",\n        \"paidAmount\": \"<number>\",\n        \"pendingAmt\": \"<number>\",\n        \"isSettled\": \"<boolean>\",\n        \"settlementType\": \"<string>\",\n        \"settlementDate\": \"<dateTime>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        },
+                                        {
+                                            "id": "744b4aed-3421-4a5e-af5b-531e8a666fe7",
+                                            "name": "Resource not found",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "ledger",
+                                                        ":payerId"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "page",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "size",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "sort",
+                                                            "value": "<string>,<string>"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "Not Found",
+                                            "code": 404,
+                                            "header": [],
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "id": "bcc06edc-54be-43e4-a2d9-a6db47e13d51",
+                            "name": "Get all ledgers",
+                            "request": {
+                                "name": "Get all ledgers",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "api",
+                                        "ledger"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "page",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "size",
+                                            "value": "<integer>"
+                                        },
+                                        {
+                                            "disabled": false,
+                                            "description": {
+                                                "content": "(Required) ",
+                                                "type": "text/plain"
+                                            },
+                                            "key": "sort",
+                                            "value": "<string>,<string>"
+                                        }
+                                    ],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "GET",
+                                "body": {},
+                                "auth": {
+                                    "type": "bearer",
+                                    "bearer": [
+                                        {
+                                            "key": "token",
+                                            "value": "{{bearerToken}}"
+                                        }
+                                    ]
+                                }
+                            },
+                            "response": [
+                                {
+                                    "id": "30d7fe78-6778-4846-a4e7-865b5ba98c2b",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "ledger"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {}
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"entryId\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"vehicleNumber\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"fromAddress\": \"<string>\",\n        \"toAddress\": \"<string>\",\n        \"driverName\": \"<string>\",\n        \"driverContactNo\": \"<string>\",\n        \"commission\": \"<number>\",\n        \"beta\": \"<number>\",\n        \"referredBy\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"paytype\": \"<string>\",\n        \"entryDate\": \"<date>\",\n        \"entryTime\": \"<dateTime>\",\n        \"exitTime\": \"<dateTime>\",\n        \"notes\": \"<string>\",\n        \"paymentReceivedBy\": \"<string>\",\n        \"paidAmount\": \"<number>\",\n        \"pendingAmt\": \"<number>\",\n        \"isSettled\": \"<boolean>\",\n        \"settlementType\": \"<string>\",\n        \"settlementDate\": \"<dateTime>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"entryId\": \"<string>\",\n        \"companyUuid\": \"<string>\",\n        \"payerId\": \"<string>\",\n        \"vehicleNumber\": \"<string>\",\n        \"vehicleType\": \"<string>\",\n        \"fromAddress\": \"<string>\",\n        \"toAddress\": \"<string>\",\n        \"driverName\": \"<string>\",\n        \"driverContactNo\": \"<string>\",\n        \"commission\": \"<number>\",\n        \"beta\": \"<number>\",\n        \"referredBy\": \"<string>\",\n        \"amount\": \"<number>\",\n        \"paytype\": \"<string>\",\n        \"entryDate\": \"<date>\",\n        \"entryTime\": \"<dateTime>\",\n        \"exitTime\": \"<dateTime>\",\n        \"notes\": \"<string>\",\n        \"paymentReceivedBy\": \"<string>\",\n        \"paidAmount\": \"<number>\",\n        \"pendingAmt\": \"<number>\",\n        \"isSettled\": \"<boolean>\",\n        \"settlementType\": \"<string>\",\n        \"settlementDate\": \"<dateTime>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        },
+                        {
+                            "name": "summary",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "4269ccb4-2e39-420b-b089-4789d2230049",
+                                    "name": "Ledger summary by payer",
+                                    "request": {
+                                        "name": "Ledger summary by payer",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "ledger",
+                                                "summary"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "b50947f1-1620-4ba9-a546-027859128235",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "ledger",
+                                                        "summary"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": [\n    {\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"pendingAmt\": \"<number>\"\n    },\n    {\n      \"payerId\": \"<string>\",\n      \"payerName\": \"<string>\",\n      \"pendingAmt\": \"<number>\"\n    }\n  ],\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "payers-ops",
+                    "description": "",
+                    "item": [
+                        {
+                            "name": "search",
+                            "description": "",
+                            "item": [
+                                {
+                                    "id": "7e4ee71e-828e-46d1-aee5-e7e34ac9ed4b",
+                                    "name": "Search active payers by name within company",
+                                    "request": {
+                                        "name": "Search active payers by name within company",
+                                        "description": {},
+                                        "url": {
+                                            "path": [
+                                                "api",
+                                                "payers-ops",
+                                                "search"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "companyUuid",
+                                                    "value": "<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "q",
+                                                    "value": "<string>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "page",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "size",
+                                                    "value": "<integer>"
+                                                },
+                                                {
+                                                    "disabled": false,
+                                                    "description": {
+                                                        "content": "(Required) ",
+                                                        "type": "text/plain"
+                                                    },
+                                                    "key": "sort",
+                                                    "value": "<string>,<string>"
+                                                }
+                                            ],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            }
+                                        ],
+                                        "method": "GET",
+                                        "body": {},
+                                        "auth": {
+                                            "type": "bearer",
+                                            "bearer": [
+                                                {
+                                                    "key": "token",
+                                                    "value": "{{bearerToken}}"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    "response": [
+                                        {
+                                            "id": "d76f6c84-fc90-445e-9243-b9f5cae2b391",
+                                            "name": "OK",
+                                            "originalRequest": {
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers-ops",
+                                                        "search"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "companyUuid",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "q",
+                                                            "value": "<string>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "page",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "size",
+                                                            "value": "<integer>"
+                                                        },
+                                                        {
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            },
+                                                            "key": "sort",
+                                                            "value": "<string>,<string>"
+                                                        }
+                                                    ],
+                                                    "variable": []
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    },
+                                                    {
+                                                        "description": {
+                                                            "content": "Added as a part of security scheme: bearer",
+                                                            "type": "text/plain"
+                                                        },
+                                                        "key": "Authorization",
+                                                        "value": "Bearer <token>"
+                                                    }
+                                                ],
+                                                "method": "GET",
+                                                "body": {}
+                                            },
+                                            "status": "OK",
+                                            "code": 200,
+                                            "header": [
+                                                {
+                                                    "key": "Content-Type",
+                                                    "value": "*/*"
+                                                }
+                                            ],
+                                            "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {\n    \"totalElements\": \"<long>\",\n    \"totalPages\": \"<integer>\",\n    \"size\": \"<integer>\",\n    \"content\": [\n      {\n        \"payerId\": \"<string>\",\n        \"payerName\": \"<string>\",\n        \"mobileNo\": \"<string>\",\n        \"payerAddress\": \"<string>\",\n        \"registrationDate\": \"<date>\",\n        \"creditLimit\": \"<integer>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      },\n      {\n        \"payerId\": \"<string>\",\n        \"payerName\": \"<string>\",\n        \"mobileNo\": \"<string>\",\n        \"payerAddress\": \"<string>\",\n        \"registrationDate\": \"<date>\",\n        \"creditLimit\": \"<integer>\",\n        \"companyUuid\": \"<string>\",\n        \"isSynced\": \"<boolean>\",\n        \"createdBy\": \"<string>\",\n        \"createdAt\": \"<dateTime>\",\n        \"updatedBy\": \"<string>\",\n        \"updatedAt\": \"<dateTime>\",\n        \"deleted\": \"<boolean>\",\n        \"deletedAt\": \"<dateTime>\",\n        \"changeId\": \"<long>\"\n      }\n    ],\n    \"number\": \"<integer>\",\n    \"sort\": {\n      \"empty\": \"<boolean>\",\n      \"unsorted\": \"<boolean>\",\n      \"sorted\": \"<boolean>\"\n    },\n    \"first\": \"<boolean>\",\n    \"last\": \"<boolean>\",\n    \"numberOfElements\": \"<integer>\",\n    \"pageable\": {\n      \"offset\": \"<long>\",\n      \"sort\": {\n        \"empty\": \"<boolean>\",\n        \"unsorted\": \"<boolean>\",\n        \"sorted\": \"<boolean>\"\n      },\n      \"paged\": \"<boolean>\",\n      \"unpaged\": \"<boolean>\",\n      \"pageNumber\": \"<integer>\",\n      \"pageSize\": \"<integer>\"\n    },\n    \"empty\": \"<boolean>\"\n  },\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                            "cookie": [],
+                                            "_postman_previewlanguage": "text"
+                                        }
+                                    ],
+                                    "event": [],
+                                    "protocolProfileBehavior": {
+                                        "disableBodyPruning": true
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "{payerId}",
+                            "description": "",
+                            "item": [
+                                {
+                                    "name": "soft",
+                                    "description": "",
+                                    "item": [
+                                        {
+                                            "id": "d15cdabd-1062-4600-93a6-88c2a6f7ffdb",
+                                            "name": "Soft delete payer (set deleted_at)",
+                                            "request": {
+                                                "name": "Soft delete payer (set deleted_at)",
+                                                "description": {},
+                                                "url": {
+                                                    "path": [
+                                                        "api",
+                                                        "payers-ops",
+                                                        ":payerId",
+                                                        "soft"
+                                                    ],
+                                                    "host": [
+                                                        "{{baseUrl}}"
+                                                    ],
+                                                    "query": [],
+                                                    "variable": [
+                                                        {
+                                                            "type": "any",
+                                                            "value": "<string>",
+                                                            "key": "payerId",
+                                                            "disabled": false,
+                                                            "description": {
+                                                                "content": "(Required) ",
+                                                                "type": "text/plain"
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                "header": [
+                                                    {
+                                                        "key": "Accept",
+                                                        "value": "*/*"
+                                                    }
+                                                ],
+                                                "method": "DELETE",
+                                                "body": {},
+                                                "auth": {
+                                                    "type": "bearer",
+                                                    "bearer": [
+                                                        {
+                                                            "key": "token",
+                                                            "value": "{{bearerToken}}"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "response": [
+                                                {
+                                                    "id": "776f1fbb-870e-4ce1-94c8-b74c991a5c0a",
+                                                    "name": "OK",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "payers-ops",
+                                                                ":payerId",
+                                                                "soft"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "key": "Accept",
+                                                                "value": "*/*"
+                                                            },
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "DELETE",
+                                                        "body": {}
+                                                    },
+                                                    "status": "OK",
+                                                    "code": 200,
+                                                    "header": [
+                                                        {
+                                                            "key": "Content-Type",
+                                                            "value": "*/*"
+                                                        }
+                                                    ],
+                                                    "body": "{\n  \"success\": \"<boolean>\",\n  \"data\": {},\n  \"errors\": [\n    \"<string>\",\n    \"<string>\"\n  ]\n}",
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                },
+                                                {
+                                                    "id": "40a1c2b6-6ba9-4472-8f82-0b3f367fce42",
+                                                    "name": "Resource not found",
+                                                    "originalRequest": {
+                                                        "url": {
+                                                            "path": [
+                                                                "api",
+                                                                "payers-ops",
+                                                                ":payerId",
+                                                                "soft"
+                                                            ],
+                                                            "host": [
+                                                                "{{baseUrl}}"
+                                                            ],
+                                                            "query": [],
+                                                            "variable": []
+                                                        },
+                                                        "header": [
+                                                            {
+                                                                "description": {
+                                                                    "content": "Added as a part of security scheme: bearer",
+                                                                    "type": "text/plain"
+                                                                },
+                                                                "key": "Authorization",
+                                                                "value": "Bearer <token>"
+                                                            }
+                                                        ],
+                                                        "method": "DELETE",
+                                                        "body": {}
+                                                    },
+                                                    "status": "Not Found",
+                                                    "code": 404,
+                                                    "header": [],
+                                                    "cookie": [],
+                                                    "_postman_previewlanguage": "text"
+                                                }
+                                            ],
+                                            "event": [],
+                                            "protocolProfileBehavior": {
+                                                "disableBodyPruning": true
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "auth",
+            "description": "",
+            "item": [
+                {
+                    "name": "register",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "c48ef450-359a-4b15-996c-a928255e2b4f",
+                            "name": "register",
+                            "request": {
+                                "name": "register",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "auth",
+                                        "register"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"id\": \"<string>\",\n  \"uuid\": \"<string>\",\n  \"employeeId\": \"<string>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyId\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<string>\",\n  \"joiningDate\": \"<string>\",\n  \"isActive\": \"<integer>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "33176718-e2b7-46b2-9ff4-83080835c607",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "auth",
+                                                "register"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"id\": \"<string>\",\n  \"uuid\": \"<string>\",\n  \"employeeId\": \"<string>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"<string>\",\n  \"password\": \"<string>\",\n  \"role\": \"<string>\",\n  \"name\": \"<string>\",\n  \"companyId\": \"<string>\",\n  \"companyName\": \"<string>\",\n  \"createdBy\": \"<string>\",\n  \"location\": \"<string>\",\n  \"dateOfBirth\": \"<string>\",\n  \"joiningDate\": \"<string>\",\n  \"isActive\": \"<integer>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"accessToken\": \"<string>\",\n  \"refreshToken\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "refresh",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "e55b2b4a-f33e-4e33-9dec-fdcdf2356511",
+                            "name": "refresh",
+                            "request": {
+                                "name": "refresh",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "auth",
+                                        "refresh"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"refreshToken\": \"<string>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "06c1485f-3cff-4d39-9324-41b40f887561",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "auth",
+                                                "refresh"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"refreshToken\": \"<string>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"accessToken\": \"<string>\",\n  \"refreshToken\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "logout",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "4bb3bdd0-ae10-4a83-a925-ed185d56084a",
+                            "name": "logout",
+                            "request": {
+                                "name": "logout",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "auth",
+                                        "logout"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"refreshToken\": \"<string>\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "981f63d1-544e-4cca-be72-5e649269155d",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "auth",
+                                                "logout"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"refreshToken\": \"<string>\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [],
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "login",
+                    "description": "",
+                    "item": [
+                        {
+                            "id": "ce57825c-ada0-4501-8578-781c754f6577",
+                            "name": "login",
+                            "request": {
+                                "name": "login",
+                                "description": {},
+                                "url": {
+                                    "path": [
+                                        "auth",
+                                        "login"
+                                    ],
+                                    "host": [
+                                        "{{baseUrl}}"
+                                    ],
+                                    "query": [],
+                                    "variable": []
+                                },
+                                "header": [
+                                    {
+                                        "key": "Content-Type",
+                                        "value": "application/json"
+                                    },
+                                    {
+                                        "key": "Accept",
+                                        "value": "*/*"
+                                    }
+                                ],
+                                "method": "POST",
+                                "body": {
+                                    "mode": "raw",
+                                    "raw": "{\n  \"password\": \"<string>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"+844386851542\"\n}",
+                                    "options": {
+                                        "raw": {
+                                            "headerFamily": "json",
+                                            "language": "json"
+                                        }
+                                    }
+                                },
+                                "auth": null
+                            },
+                            "response": [
+                                {
+                                    "id": "c9cdfe2c-c927-4305-8483-1b1e0403989e",
+                                    "name": "OK",
+                                    "originalRequest": {
+                                        "url": {
+                                            "path": [
+                                                "auth",
+                                                "login"
+                                            ],
+                                            "host": [
+                                                "{{baseUrl}}"
+                                            ],
+                                            "query": [],
+                                            "variable": []
+                                        },
+                                        "header": [
+                                            {
+                                                "key": "Content-Type",
+                                                "value": "application/json"
+                                            },
+                                            {
+                                                "key": "Accept",
+                                                "value": "*/*"
+                                            },
+                                            {
+                                                "description": {
+                                                    "content": "Added as a part of security scheme: bearer",
+                                                    "type": "text/plain"
+                                                },
+                                                "key": "Authorization",
+                                                "value": "Bearer <token>"
+                                            }
+                                        ],
+                                        "method": "POST",
+                                        "body": {
+                                            "mode": "raw",
+                                            "raw": "{\n  \"password\": \"<string>\",\n  \"email\": \"<string>\",\n  \"mobileNo\": \"+844386851542\"\n}",
+                                            "options": {
+                                                "raw": {
+                                                    "headerFamily": "json",
+                                                    "language": "json"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "status": "OK",
+                                    "code": 200,
+                                    "header": [
+                                        {
+                                            "key": "Content-Type",
+                                            "value": "*/*"
+                                        }
+                                    ],
+                                    "body": "{\n  \"accessToken\": \"<string>\",\n  \"refreshToken\": \"<string>\"\n}",
+                                    "cookie": [],
+                                    "_postman_previewlanguage": "text"
+                                }
+                            ],
+                            "event": [],
+                            "protocolProfileBehavior": {
+                                "disableBodyPruning": true
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "auth": {
+        "type": "bearer",
+        "bearer": [
+            {
+                "type": "any",
+                "value": "{{bearerToken}}",
+                "key": "token"
+            }
+        ]
+    },
+    "event": [],
+    "variable": [
+        {
+            "key": "baseUrl",
+            "value": "http://localhost:8080"
+        }
+    ],
+    "info": {
+        "_postman_id": "9a48d4a1-6452-4d7a-8d54-1619f0cea872",
+        "name": "Easyreach API",
+        "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+        "description": {
+            "content": "",
+            "type": "text/plain"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add 404 "Resource not found" response for endpoints with path parameters in OpenAPI spec
- regenerate Postman collection from updated spec

## Testing
- `mvn -q clean verify` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:3.2.5)*


------
https://chatgpt.com/codex/tasks/task_e_68bc678e0ebc832da76e1119c2428048