### PR TITLE
Ensure stable entity IDs across integration tests

### DIFF
--- a/api-tests/src/test/java/com/easyreach/tests/companies/CompanyIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/companies/CompanyIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.companies;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -35,7 +36,7 @@ public class CompanyIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetCompany() {
-        String id = IdStore.get("companyUuid");
+        String id = ensureCompany();
         Response r = given().spec(spec).get("/api/companies/" + id);
         r.then().statusCode(200).body("data.uuid", equalTo(id));
     }
@@ -51,7 +52,7 @@ public class CompanyIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateCompany() {
-        String id = IdStore.get("companyUuid");
+        String id = ensureCompany();
         Map<String, Object> body = SampleData.companyRequest();
         body.put("uuid", id);
         body.put("companyName", "Updated Co");
@@ -63,7 +64,7 @@ public class CompanyIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteCompany() {
-        String id = IdStore.get("companyUuid");
+        String id = ensureCompany();
         given().spec(spec).delete("/api/companies/" + id)
                 .then().statusCode(200);
     }

--- a/api-tests/src/test/java/com/easyreach/tests/core/EntityHelper.java
+++ b/api-tests/src/test/java/com/easyreach/tests/core/EntityHelper.java
@@ -1,0 +1,44 @@
+package com.easyreach.tests.core;
+
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+
+public class EntityHelper {
+    public static String ensureCompany() {
+        String id = IdStore.get("companyUuid");
+        if (id == null) {
+            Map<String, Object> body = SampleData.companyRequest();
+            Response r = given().spec(BaseIT.spec).body(body).post("/api/companies");
+            id = r.jsonPath().getString("data.uuid");
+            IdStore.put("companyUuid", id);
+        }
+        return id;
+    }
+
+    public static String ensurePayer() {
+        String id = IdStore.get("payerId");
+        if (id == null) {
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.payerRequest(companyId);
+            Response r = given().spec(BaseIT.spec).body(body).post("/api/payers");
+            id = r.jsonPath().getString("data.payerId");
+            IdStore.put("payerId", id);
+        }
+        return id;
+    }
+
+    public static String ensureUser() {
+        String id = IdStore.get("userId");
+        if (id == null) {
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.userRequest(companyId);
+            Response r = given().spec(BaseIT.spec).body(body).post("/api/users");
+            id = r.jsonPath().getString("data.id");
+            IdStore.put("userId", id);
+        }
+        return id;
+    }
+}

--- a/api-tests/src/test/java/com/easyreach/tests/entries/VehicleEntryIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/entries/VehicleEntryIT.java
@@ -3,6 +3,8 @@ package com.easyreach.tests.entries;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
+import static com.easyreach.tests.core.EntityHelper.ensurePayer;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -33,7 +35,7 @@ public class VehicleEntryIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetVehicleEntry() {
-        String id = IdStore.get("entryId");
+        String id = ensureVehicleEntry();
         given().spec(spec).get("/api/vehicle-entries/" + id)
                 .then().statusCode(200).body("data.entryId", equalTo(id));
     }
@@ -49,9 +51,9 @@ public class VehicleEntryIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateVehicleEntry() {
-        String id = IdStore.get("entryId");
-        String companyId = IdStore.get("companyUuid");
-        String payerId = IdStore.get("payerId");
+        String id = ensureVehicleEntry();
+        String companyId = ensureCompany();
+        String payerId = ensurePayer();
         Map<String, Object> body = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
         body.put("entryId", id);
         body.put("amount", 1500);
@@ -63,30 +65,20 @@ public class VehicleEntryIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteVehicleEntry() {
-        String id = IdStore.get("entryId");
+        String id = ensureVehicleEntry();
         given().spec(spec).delete("/api/vehicle-entries/" + id)
                 .then().statusCode(200);
     }
 
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
-        if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
-        }
-        return id;
-    }
-
-    private String ensurePayer() {
-        String id = IdStore.get("payerId");
+    private String ensureVehicleEntry() {
+        String id = IdStore.get("entryId");
         if (id == null) {
             String companyId = ensureCompany();
-            Map<String, Object> body = SampleData.payerRequest(companyId);
-            Response r = given().spec(spec).body(body).post("/api/payers");
-            id = r.jsonPath().getString("data.payerId");
-            IdStore.put("payerId", id);
+            String payerId = ensurePayer();
+            Map<String, Object> body = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
+            Response r = given().spec(spec).body(body).post("/api/vehicle-entries");
+            id = r.jsonPath().getString("data.entryId");
+            IdStore.put("entryId", id);
         }
         return id;
     }

--- a/api-tests/src/test/java/com/easyreach/tests/equipment/EquipmentUsageIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/equipment/EquipmentUsageIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.equipment;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -32,7 +33,7 @@ public class EquipmentUsageIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetEquipmentUsage() {
-        String id = IdStore.get("equipmentUsageId");
+        String id = ensureEquipmentUsage();
         given().spec(spec).get("/api/equipment-usage/" + id)
                 .then().statusCode(200).body("data.equipmentUsageId", equalTo(id));
     }
@@ -48,8 +49,8 @@ public class EquipmentUsageIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateEquipmentUsage() {
-        String id = IdStore.get("equipmentUsageId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureEquipmentUsage();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.equipmentUsageRequest(companyId);
         body.put("equipmentUsageId", id);
         body.put("endKm", 20);
@@ -61,18 +62,19 @@ public class EquipmentUsageIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteEquipmentUsage() {
-        String id = IdStore.get("equipmentUsageId");
+        String id = ensureEquipmentUsage();
         given().spec(spec).delete("/api/equipment-usage/" + id)
                 .then().statusCode(200);
     }
 
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
+    private String ensureEquipmentUsage() {
+        String id = IdStore.get("equipmentUsageId");
         if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.equipmentUsageRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/equipment-usage");
+            id = r.jsonPath().getString("data.equipmentUsageId");
+            IdStore.put("equipmentUsageId", id);
         }
         return id;
     }

--- a/api-tests/src/test/java/com/easyreach/tests/expenses/DailyExpenseIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/expenses/DailyExpenseIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.expenses;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -33,7 +34,7 @@ public class DailyExpenseIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetDailyExpense() {
-        String id = IdStore.get("dailyExpenseId");
+        String id = ensureDailyExpense();
         given().spec(spec).get("/api/daily-expenses/" + id)
                 .then().statusCode(200).body("data.expenseId", equalTo(id));
     }
@@ -51,8 +52,8 @@ public class DailyExpenseIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateDailyExpense() {
-        String id = IdStore.get("dailyExpenseId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureDailyExpense();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.dailyExpenseRequest(companyId);
         body.put("expenseId", id);
         body.put("expenseAmount", 200);
@@ -64,18 +65,19 @@ public class DailyExpenseIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteDailyExpense() {
-        String id = IdStore.get("dailyExpenseId");
+        String id = ensureDailyExpense();
         given().spec(spec).delete("/api/daily-expenses/" + id)
                 .then().statusCode(200);
     }
 
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
+    private String ensureDailyExpense() {
+        String id = IdStore.get("dailyExpenseId");
         if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.dailyExpenseRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/daily-expenses");
+            id = r.jsonPath().getString("data.expenseId");
+            IdStore.put("dailyExpenseId", id);
         }
         return id;
     }

--- a/api-tests/src/test/java/com/easyreach/tests/expenses/ExpenseMasterIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/expenses/ExpenseMasterIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.expenses;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -32,7 +33,7 @@ public class ExpenseMasterIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetExpenseMaster() {
-        String id = IdStore.get("expenseMasterId");
+        String id = ensureExpenseMaster();
         given().spec(spec).get("/api/expense-master/" + id)
                 .then().statusCode(200).body("data.id", equalTo(id));
     }
@@ -48,8 +49,8 @@ public class ExpenseMasterIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateExpenseMaster() {
-        String id = IdStore.get("expenseMasterId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureExpenseMaster();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.expenseMasterRequest(companyId);
         body.put("id", id);
         body.put("expenseName", "UpdatedExpense");
@@ -61,18 +62,19 @@ public class ExpenseMasterIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteExpenseMaster() {
-        String id = IdStore.get("expenseMasterId");
+        String id = ensureExpenseMaster();
         given().spec(spec).delete("/api/expense-master/" + id)
                 .then().statusCode(200);
     }
 
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
+    private String ensureExpenseMaster() {
+        String id = IdStore.get("expenseMasterId");
         if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.expenseMasterRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/expense-master");
+            id = r.jsonPath().getString("data.id");
+            IdStore.put("expenseMasterId", id);
         }
         return id;
     }

--- a/api-tests/src/test/java/com/easyreach/tests/fuel/DieselUsageIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/fuel/DieselUsageIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.fuel;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -32,7 +33,7 @@ public class DieselUsageIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetDieselUsage() {
-        String id = IdStore.get("dieselUsageId");
+        String id = ensureDieselUsage();
         given().spec(spec).get("/api/diesel-usage/" + id)
                 .then().statusCode(200).body("data.dieselUsageId", equalTo(id));
     }
@@ -48,8 +49,8 @@ public class DieselUsageIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateDieselUsage() {
-        String id = IdStore.get("dieselUsageId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureDieselUsage();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.dieselUsageRequest(companyId, "VehicleA");
         body.put("dieselUsageId", id);
         body.put("liters", 60);
@@ -61,18 +62,19 @@ public class DieselUsageIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteDieselUsage() {
-        String id = IdStore.get("dieselUsageId");
+        String id = ensureDieselUsage();
         given().spec(spec).delete("/api/diesel-usage/" + id)
                 .then().statusCode(200);
     }
 
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
+    private String ensureDieselUsage() {
+        String id = IdStore.get("dieselUsageId");
         if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.dieselUsageRequest(companyId, "VehicleA");
+            Response r = given().spec(spec).body(body).post("/api/diesel-usage");
+            id = r.jsonPath().getString("data.dieselUsageId");
+            IdStore.put("dieselUsageId", id);
         }
         return id;
     }

--- a/api-tests/src/test/java/com/easyreach/tests/ledger/LedgerIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/ledger/LedgerIT.java
@@ -3,6 +3,8 @@ package com.easyreach.tests.ledger;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
+import static com.easyreach.tests.core.EntityHelper.ensurePayer;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -20,20 +22,8 @@ import static org.hamcrest.Matchers.*;
 public class LedgerIT extends BaseIT {
     private void ensureLedgerData() {
         if (IdStore.get("entryId") == null) {
-            String companyId = IdStore.get("companyUuid");
-            if (companyId == null) {
-                Map<String, Object> company = SampleData.companyRequest();
-                Response cr = given().spec(spec).body(company).post("/api/companies");
-                companyId = cr.jsonPath().getString("data.uuid");
-                IdStore.put("companyUuid", companyId);
-            }
-            String payerId = IdStore.get("payerId");
-            if (payerId == null) {
-                Map<String, Object> payer = SampleData.payerRequest(companyId);
-                Response pr = given().spec(spec).body(payer).post("/api/payers");
-                payerId = pr.jsonPath().getString("data.payerId");
-                IdStore.put("payerId", payerId);
-            }
+            String companyId = ensureCompany();
+            String payerId = ensurePayer();
             Map<String, Object> entry = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
             Response er = given().spec(spec).body(entry).post("/api/vehicle-entries");
             String entryId = er.jsonPath().getString("data.entryId");

--- a/api-tests/src/test/java/com/easyreach/tests/ops/PayerOpsIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/ops/PayerOpsIT.java
@@ -2,15 +2,12 @@ package com.easyreach.tests.ops;
 
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
-import com.easyreach.tests.core.SampleData;
-import io.restassured.response.Response;
+import static com.easyreach.tests.core.EntityHelper.ensurePayer;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
-
-import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -18,22 +15,6 @@ import static org.hamcrest.Matchers.*;
 @Tag("e2e")
 @TestMethodOrder(OrderAnnotation.class)
 public class PayerOpsIT extends BaseIT {
-    private void ensurePayer() {
-        if (IdStore.get("payerId") == null) {
-            String companyId = IdStore.get("companyUuid");
-            if (companyId == null) {
-                Map<String, Object> company = SampleData.companyRequest();
-                Response cr = given().spec(spec).body(company).post("/api/companies");
-                companyId = cr.jsonPath().getString("data.uuid");
-                IdStore.put("companyUuid", companyId);
-            }
-            Map<String, Object> payer = SampleData.payerRequest(companyId);
-            Response pr = given().spec(spec).body(payer).post("/api/payers");
-            String payerId = pr.jsonPath().getString("data.payerId");
-            IdStore.put("payerId", payerId);
-        }
-    }
-
     @Test
     @Order(1)
     void shouldSearchPayers() {

--- a/api-tests/src/test/java/com/easyreach/tests/ops/VehicleEntryOpsIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/ops/VehicleEntryOpsIT.java
@@ -3,6 +3,8 @@ package com.easyreach.tests.ops;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
+import static com.easyreach.tests.core.EntityHelper.ensurePayer;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -23,20 +25,8 @@ public class VehicleEntryOpsIT extends BaseIT {
         String id = IdStore.get("entryId");
         if (id == null) {
             // create dependencies
-            String companyId = IdStore.get("companyUuid");
-            if (companyId == null) {
-                Map<String, Object> company = SampleData.companyRequest();
-                Response cr = given().spec(spec).body(company).post("/api/companies");
-                companyId = cr.jsonPath().getString("data.uuid");
-                IdStore.put("companyUuid", companyId);
-            }
-            String payerId = IdStore.get("payerId");
-            if (payerId == null) {
-                Map<String, Object> payer = SampleData.payerRequest(companyId);
-                Response pr = given().spec(spec).body(payer).post("/api/payers");
-                payerId = pr.jsonPath().getString("data.payerId");
-                IdStore.put("payerId", payerId);
-            }
+            String companyId = ensureCompany();
+            String payerId = ensurePayer();
             Map<String, Object> entry = SampleData.vehicleEntryRequest(companyId, payerId, "TRUCK");
             Response er = given().spec(spec).body(entry).post("/api/vehicle-entries");
             id = er.jsonPath().getString("data.entryId");

--- a/api-tests/src/test/java/com/easyreach/tests/payers/PayerIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/payers/PayerIT.java
@@ -3,6 +3,8 @@ package com.easyreach.tests.payers;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
+import static com.easyreach.tests.core.EntityHelper.ensurePayer;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -32,7 +34,7 @@ public class PayerIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetPayer() {
-        String id = IdStore.get("payerId");
+        String id = ensurePayer();
         given().spec(spec).get("/api/payers/" + id)
                 .then().statusCode(200).body("data.payerId", equalTo(id));
     }
@@ -48,8 +50,8 @@ public class PayerIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdatePayer() {
-        String id = IdStore.get("payerId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensurePayer();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.payerRequest(companyId);
         body.put("payerId", id);
         body.put("payerName", "Updated Payer");
@@ -61,19 +63,8 @@ public class PayerIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeletePayer() {
-        String id = IdStore.get("payerId");
+        String id = ensurePayer();
         given().spec(spec).delete("/api/payers/" + id)
                 .then().statusCode(200);
-    }
-
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
-        if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
-        }
-        return id;
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/payers/PayerSettlementIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/payers/PayerSettlementIT.java
@@ -3,6 +3,8 @@ package com.easyreach.tests.payers;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
+import static com.easyreach.tests.core.EntityHelper.ensurePayer;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -33,7 +35,7 @@ public class PayerSettlementIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetPayerSettlement() {
-        String id = IdStore.get("settlementId");
+        String id = ensurePayerSettlement();
         given().spec(spec).get("/api/payer-settlements/" + id)
                 .then().statusCode(200).body("data.settlementId", equalTo(id));
     }
@@ -49,9 +51,9 @@ public class PayerSettlementIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdatePayerSettlement() {
-        String id = IdStore.get("settlementId");
-        String companyId = IdStore.get("companyUuid");
-        String payerId = IdStore.get("payerId");
+        String id = ensurePayerSettlement();
+        String companyId = ensureCompany();
+        String payerId = ensurePayer();
         Map<String, Object> body = SampleData.payerSettlementRequest(companyId, payerId);
         body.put("settlementId", id);
         body.put("amount", 200);
@@ -63,8 +65,9 @@ public class PayerSettlementIT extends BaseIT {
     @Test
     @Order(5)
     void shouldGetByPayerAndCompany() {
-        String payerId = IdStore.get("payerId");
-        String companyId = IdStore.get("companyUuid");
+        ensurePayerSettlement();
+        String payerId = ensurePayer();
+        String companyId = ensureCompany();
         given().spec(spec).get("/api/payer-settlements/payer/" + payerId)
                 .then().statusCode(200).body("data", notNullValue());
         given().spec(spec).get("/api/payer-settlements/company/" + companyId)
@@ -74,30 +77,20 @@ public class PayerSettlementIT extends BaseIT {
     @Test
     @Order(6)
     void shouldDeletePayerSettlement() {
-        String id = IdStore.get("settlementId");
+        String id = ensurePayerSettlement();
         given().spec(spec).delete("/api/payer-settlements/" + id)
                 .then().statusCode(200);
     }
 
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
-        if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
-        }
-        return id;
-    }
-
-    private String ensurePayer() {
-        String id = IdStore.get("payerId");
+    private String ensurePayerSettlement() {
+        String id = IdStore.get("settlementId");
         if (id == null) {
             String companyId = ensureCompany();
-            Map<String, Object> body = SampleData.payerRequest(companyId);
-            Response r = given().spec(spec).body(body).post("/api/payers");
-            id = r.jsonPath().getString("data.payerId");
-            IdStore.put("payerId", id);
+            String payerId = ensurePayer();
+            Map<String, Object> body = SampleData.payerSettlementRequest(companyId, payerId);
+            Response r = given().spec(spec).body(body).post("/api/payer-settlements");
+            id = r.jsonPath().getString("data.settlementId");
+            IdStore.put("settlementId", id);
         }
         return id;
     }

--- a/api-tests/src/test/java/com/easyreach/tests/users/UserIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/users/UserIT.java
@@ -3,6 +3,8 @@ package com.easyreach.tests.users;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
+import static com.easyreach.tests.core.EntityHelper.ensureUser;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -32,7 +34,7 @@ public class UserIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetUser() {
-        String id = IdStore.get("userId");
+        String id = ensureUser();
         given().spec(spec).get("/api/users/" + id)
                 .then().statusCode(200).body("data.id", equalTo(id));
     }
@@ -48,8 +50,8 @@ public class UserIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateUser() {
-        String id = IdStore.get("userId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureUser();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.userRequest(companyId);
         body.put("id", id);
         body.put("name", "Updated User");
@@ -61,19 +63,8 @@ public class UserIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteUser() {
-        String id = IdStore.get("userId");
+        String id = ensureUser();
         given().spec(spec).delete("/api/users/" + id)
                 .then().statusCode(200);
-    }
-
-    private String ensureCompany() {
-        String id = IdStore.get("companyUuid");
-        if (id == null) {
-            Map<String, Object> body = SampleData.companyRequest();
-            Response r = given().spec(spec).body(body).post("/api/companies");
-            id = r.jsonPath().getString("data.uuid");
-            IdStore.put("companyUuid", id);
-        }
-        return id;
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/vehicles/InternalVehicleIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/vehicles/InternalVehicleIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.vehicles;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -21,10 +22,7 @@ public class InternalVehicleIT extends BaseIT {
     @Test
     @Order(1)
     void shouldCreateInternalVehicle() {
-        String companyId = IdStore.get("companyUuid");
-        if (companyId == null) {
-            companyId = createCompany();
-        }
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.internalVehicleRequest(companyId);
         Response r = given().spec(spec).body(body).post("/api/internal-vehicles");
         r.then().statusCode(200);
@@ -35,7 +33,7 @@ public class InternalVehicleIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetInternalVehicle() {
-        String id = IdStore.get("internalVehicleId");
+        String id = ensureInternalVehicle();
         given().spec(spec).get("/api/internal-vehicles/" + id)
                 .then().statusCode(200).body("data.vehicleId", equalTo(id));
     }
@@ -51,8 +49,8 @@ public class InternalVehicleIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateInternalVehicle() {
-        String id = IdStore.get("internalVehicleId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureInternalVehicle();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.internalVehicleRequest(companyId);
         body.put("vehicleId", id);
         body.put("vehicleName", "UpdatedVehicle");
@@ -64,16 +62,20 @@ public class InternalVehicleIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteInternalVehicle() {
-        String id = IdStore.get("internalVehicleId");
+        String id = ensureInternalVehicle();
         given().spec(spec).delete("/api/internal-vehicles/" + id)
                 .then().statusCode(200);
     }
 
-    private String createCompany() {
-        Map<String, Object> body = SampleData.companyRequest();
-        Response r = given().spec(spec).body(body).post("/api/companies");
-        String id = r.jsonPath().getString("data.uuid");
-        IdStore.put("companyUuid", id);
+    private String ensureInternalVehicle() {
+        String id = IdStore.get("internalVehicleId");
+        if (id == null) {
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.internalVehicleRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/internal-vehicles");
+            id = r.jsonPath().getString("data.vehicleId");
+            IdStore.put("internalVehicleId", id);
+        }
         return id;
     }
 }

--- a/api-tests/src/test/java/com/easyreach/tests/vehicles/VehicleTypeIT.java
+++ b/api-tests/src/test/java/com/easyreach/tests/vehicles/VehicleTypeIT.java
@@ -3,6 +3,7 @@ package com.easyreach.tests.vehicles;
 import com.easyreach.tests.core.BaseIT;
 import com.easyreach.tests.core.IdStore;
 import com.easyreach.tests.core.SampleData;
+import static com.easyreach.tests.core.EntityHelper.ensureCompany;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -21,10 +22,7 @@ public class VehicleTypeIT extends BaseIT {
     @Test
     @Order(1)
     void shouldCreateVehicleType() {
-        String companyId = IdStore.get("companyUuid");
-        if (companyId == null) {
-            companyId = createCompany();
-        }
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.vehicleTypeRequest(companyId);
         Response r = given().spec(spec).body(body).post("/api/vehicle-types");
         r.then().statusCode(200);
@@ -35,7 +33,7 @@ public class VehicleTypeIT extends BaseIT {
     @Test
     @Order(2)
     void shouldGetVehicleType() {
-        String id = IdStore.get("vehicleTypeId");
+        String id = ensureVehicleType();
         given().spec(spec).get("/api/vehicle-types/" + id)
                 .then().statusCode(200).body("data.id", equalTo(id));
     }
@@ -51,8 +49,8 @@ public class VehicleTypeIT extends BaseIT {
     @Test
     @Order(4)
     void shouldUpdateVehicleType() {
-        String id = IdStore.get("vehicleTypeId");
-        String companyId = IdStore.get("companyUuid");
+        String id = ensureVehicleType();
+        String companyId = ensureCompany();
         Map<String, Object> body = SampleData.vehicleTypeRequest(companyId);
         body.put("id", id);
         body.put("vehicleType", "UpdatedType");
@@ -64,16 +62,20 @@ public class VehicleTypeIT extends BaseIT {
     @Test
     @Order(5)
     void shouldDeleteVehicleType() {
-        String id = IdStore.get("vehicleTypeId");
+        String id = ensureVehicleType();
         given().spec(spec).delete("/api/vehicle-types/" + id)
                 .then().statusCode(200);
     }
 
-    private String createCompany() {
-        Map<String, Object> body = SampleData.companyRequest();
-        Response r = given().spec(spec).body(body).post("/api/companies");
-        String id = r.jsonPath().getString("data.uuid");
-        IdStore.put("companyUuid", id);
+    private String ensureVehicleType() {
+        String id = IdStore.get("vehicleTypeId");
+        if (id == null) {
+            String companyId = ensureCompany();
+            Map<String, Object> body = SampleData.vehicleTypeRequest(companyId);
+            Response r = given().spec(spec).body(body).post("/api/vehicle-types");
+            id = r.jsonPath().getString("data.id");
+            IdStore.put("vehicleTypeId", id);
+        }
         return id;
     }
 }


### PR DESCRIPTION
## Summary
- centralize common entity creation helpers in EntityHelper
- add ensure<entity> methods and invoke before get/update/delete tests
- refactor tests to reuse shared helpers for company, payer, and user

## Testing
- `mvn -q -pl api-tests test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc67425050832d97f36c6c19ab06cf