### PR TITLE
Avoid serializing null JSON fields

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -32,6 +32,7 @@ spring:
 
   jackson:
     time-zone: Asia/Kolkata
+    default-property-inclusion: non_null
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Summary
- configure Jackson to omit null values from JSON serialization

## Testing
- `mvn -q -pl backend -am -Djava.net.preferIPv4Stack=true clean package` *(fails: Could not transfer artifact: Network is unreachable)*
- `mvn -q -pl api-tests -am test` *(fails: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6b64c63c832d95eccaa43ff485a1