### PR TITLE
test: expand unit test coverage

### DIFF
--- a/backend/src/test/java/com/easyreach/backend/auth/validation/EmailOrMobileRequiredValidatorTest.java
+++ b/backend/src/test/java/com/easyreach/backend/auth/validation/EmailOrMobileRequiredValidatorTest.java
@@ -1,0 +1,58 @@
+package com.easyreach.backend.auth.validation;
+
+import com.easyreach.backend.auth.dto.LoginRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailOrMobileRequiredValidatorTest {
+
+    private final EmailOrMobileRequiredValidator validator = new EmailOrMobileRequiredValidator();
+
+    @Test
+    void nullValueIsValid() {
+        assertTrue(validator.isValid(null, null));
+    }
+
+    @Test
+    void bothEmailAndMobileMissingIsInvalid() {
+        LoginRequest req = new LoginRequest();
+        req.setPassword("pass");
+        assertFalse(validator.isValid(req, null));
+    }
+
+    @Test
+    void emailOnlyIsValid() {
+        LoginRequest req = new LoginRequest();
+        req.setEmail("user@example.com");
+        req.setPassword("pass");
+        assertTrue(validator.isValid(req, null));
+    }
+
+    @Test
+    void mobileOnlyIsValid() {
+        LoginRequest req = new LoginRequest();
+        req.setMobileNo("+12345678901");
+        req.setPassword("pass");
+        assertTrue(validator.isValid(req, null));
+    }
+
+    @Test
+    void blankEmailAndMobileAreTreatedAsMissing() {
+        LoginRequest req = new LoginRequest();
+        req.setEmail(" ");
+        req.setMobileNo("   ");
+        req.setPassword("pass");
+        assertFalse(validator.isValid(req, null));
+    }
+
+    @Test
+    void bothEmailAndMobilePresentIsValid() {
+        LoginRequest req = new LoginRequest();
+        req.setEmail("user@example.com");
+        req.setMobileNo("+12345678901");
+        req.setPassword("pass");
+        assertTrue(validator.isValid(req, null));
+    }
+}
+

--- a/backend/src/test/java/com/easyreach/backend/dto/ApiResponseTest.java
+++ b/backend/src/test/java/com/easyreach/backend/dto/ApiResponseTest.java
@@ -1,0 +1,37 @@
+package com.easyreach.backend.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiResponseTest {
+
+    @Test
+    void successFactoryPopulatesFields() {
+        ApiResponse<String> response = ApiResponse.success("data");
+        assertTrue(response.isSuccess());
+        assertEquals("data", response.getData());
+        assertNotNull(response.getErrors());
+        assertTrue(response.getErrors().isEmpty());
+    }
+
+    @Test
+    void failureWithListFactoryPopulatesErrors() {
+        List<String> errors = List.of("e1", "e2");
+        ApiResponse<Object> response = ApiResponse.failure(errors);
+        assertFalse(response.isSuccess());
+        assertNull(response.getData());
+        assertEquals(errors, response.getErrors());
+    }
+
+    @Test
+    void failureWithSingleErrorFactoryCreatesList() {
+        ApiResponse<Object> response = ApiResponse.failure("boom");
+        assertFalse(response.isSuccess());
+        assertNull(response.getData());
+        assertEquals(List.of("boom"), response.getErrors());
+    }
+}
+

--- a/backend/src/test/java/com/easyreach/backend/util/CodeGeneratorTest.java
+++ b/backend/src/test/java/com/easyreach/backend/util/CodeGeneratorTest.java
@@ -3,15 +3,46 @@ package com.easyreach.backend.util;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 class CodeGeneratorTest {
 
     @Test
-    void generateUsesProvidedUuidSupplier() {
+    void generateUsesPrefixAndUpperCaseRandomSection() {
         UUID fixed = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
         CodeGenerator generator = new CodeGenerator(() -> fixed);
-        assertThat(generator.generate("C-")).isEqualTo("C-123E4567");
+
+        String result = generator.generate("PRE-");
+
+        assertEquals("PRE-123E4567", result);
+        assertEquals(12, result.length());
+    }
+
+    @Test
+    void generateHandlesEmptyPrefix() {
+        UUID fixed = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        CodeGenerator generator = new CodeGenerator(() -> fixed);
+
+        String result = generator.generate("");
+
+        assertEquals("123E4567", result);
+    }
+
+    @Test
+    void generateProducesDifferentValuesForDifferentUuids() {
+        UUID first = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+        UUID second = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
+        AtomicInteger counter = new AtomicInteger();
+        Supplier<UUID> supplier = () -> counter.getAndIncrement() == 0 ? first : second;
+        CodeGenerator generator = new CodeGenerator(supplier);
+
+        String one = generator.generate("X");
+        String two = generator.generate("X");
+
+        assertNotEquals(one, two);
     }
 }
+


### PR DESCRIPTION
## Summary
- enhance CodeGenerator tests for prefix, empty prefix, and unique results
- add EmailOrMobileRequiredValidator tests for valid/invalid login scenarios
- cover ApiResponse success and failure factory methods

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93cd19a8832d850788502f0b7dd3