### PR TITLE
Make sand quantity receipt specific

### DIFF
--- a/backend/src/main/java/com/easyreach/backend/controller/ReceiptFormController.java
+++ b/backend/src/main/java/com/easyreach/backend/controller/ReceiptFormController.java
@@ -61,7 +61,7 @@ public class ReceiptFormController {
         data.tripNo = receipt.getTripNo();
         data.customerName = order.getCustomerName();
         data.customerMobile = order.getCustomerMobile();
-        data.sandQuantity = order.getSandQuantity();
+        data.sandQuantity = receipt.getSandQuantity();
         data.supplyPoint = order.getSupplyPoint();
         data.dispatchDateTime = dto.getDispatchDateTime();
         data.driverName = dto.getDriverName();

--- a/backend/src/main/java/com/easyreach/backend/entity/Order.java
+++ b/backend/src/main/java/com/easyreach/backend/entity/Order.java
@@ -35,9 +35,6 @@ public class Order {
     @Column(name = "customer_mobile")
     private String customerMobile;
 
-    @Column(name = "sand_quantity")
-    private String sandQuantity;
-
     @Column(name = "supply_point")
     private String supplyPoint;
 

--- a/backend/src/main/java/com/easyreach/backend/service/impl/ReceiptPdfService.java
+++ b/backend/src/main/java/com/easyreach/backend/service/impl/ReceiptPdfService.java
@@ -71,8 +71,8 @@ public class ReceiptPdfService {
         List<Map<String, String>> rows = new ArrayList<>();
         rows.add(Map.of("label", "Order Id", "value", d.orderId));
         rows.add(Map.of("label", "Trip No", "value", d.tripNo));
-        rows.add(Map.of("label", "Customer Name", "value", d.customerName));
-        rows.add(Map.of("label", "Customer Mobile", "value", d.customerMobile));
+        rows.add(Map.of("label", "Consumer Name", "value", d.customerName));
+        rows.add(Map.of("label", "Consumer Mobile", "value", d.customerMobile));
         double qty = Double.parseDouble(d.sandQuantity);
         rows.add(Map.of("label", "Sand Quantity", "value", String.format(Locale.ENGLISH, "%.1fTons", qty)));
         rows.add(Map.of("label", "Sand Supply Point Name", "value", SUPPLY_POINT));

--- a/backend/src/main/java/com/easyreach/backend/service/impl/ReceiptServiceImpl.java
+++ b/backend/src/main/java/com/easyreach/backend/service/impl/ReceiptServiceImpl.java
@@ -38,7 +38,7 @@ public class ReceiptServiceImpl implements ReceiptService {
                 .tripNo(String.valueOf(nextTrip))
                 .customerName(order.getCustomerName())
                 .customerMobile(order.getCustomerMobile())
-                .sandQuantity(order.getSandQuantity())
+                .sandQuantity(dto.getSandQuantity())
                 .supplyPoint(order.getSupplyPoint())
                 .dispatchDateTime(dto.getDispatchDateTime())
                 .driverName(dto.getDriverName())

--- a/backend/src/main/resources/db/migration/V7__drop_sand_quantity_from_orders.sql
+++ b/backend/src/main/resources/db/migration/V7__drop_sand_quantity_from_orders.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders DROP COLUMN IF EXISTS sand_quantity;

--- a/backend/src/main/resources/templates/orders/order_form.html
+++ b/backend/src/main/resources/templates/orders/order_form.html
@@ -22,16 +22,6 @@
         <input class="form-control" type="text" name="customerMobile">
     </div>
     <div class="mb-3">
-        <label class="form-label">Sand Quantity</label>
-        <select class="form-select" name="sandQuantity">
-            <option value="10">10</option>
-            <option value="20">20</option>
-            <option value="25">25</option>
-            <option value="30">30</option>
-            <option value="35">35</option>
-        </select>
-    </div>
-    <div class="mb-3">
         <label class="form-label">Supply Point</label>
         <input class="form-control" type="text" name="supplyPoint">
     </div>

--- a/backend/src/main/resources/templates/receipts/receipt_form.html
+++ b/backend/src/main/resources/templates/receipts/receipt_form.html
@@ -23,16 +23,22 @@
         <input class="form-control" type="text" name="tripNo" readonly>
     </div>
     <div class="mb-3">
-        <label class="form-label">Customer Name</label>
+        <label class="form-label">Consumer Name</label>
         <input class="form-control" type="text" name="customerName" readonly>
     </div>
     <div class="mb-3">
-        <label class="form-label">Customer Mobile</label>
+        <label class="form-label">Consumer Mobile</label>
         <input class="form-control" type="text" name="customerMobile" readonly>
     </div>
     <div class="mb-3">
         <label class="form-label">Sand Quantity</label>
-        <input class="form-control" type="text" name="sandQuantity" readonly>
+        <select class="form-select" name="sandQuantity" required>
+            <option value="10">10</option>
+            <option value="20">20</option>
+            <option value="25">25</option>
+            <option value="30">30</option>
+            <option value="35">35</option>
+        </select>
     </div>
     <div class="mb-3">
         <label class="form-label">Dispatch Date/Time</label>
@@ -76,14 +82,22 @@
       orderSelect.addEventListener('change', async () => {
           const orderId = orderSelect.value;
           if (!orderId) return;
-          const res = await fetch(`/api/orders/${orderId}`, { headers: { 'Authorization': 'Bearer ' + token }});
-          if (!res.ok) return;
-          const data = await res.json();
-          document.querySelector('input[name="tripNo"]').value = (data.tripNo || 0) + 1;
-          document.querySelector('input[name="customerName"]').value = data.customerName || '';
-          document.querySelector('input[name="customerMobile"]').value = data.customerMobile || '';
-          document.querySelector('input[name="sandQuantity"]').value = data.sandQuantity || '';
-          document.querySelector('textarea[name="address"]').value = data.fullAddress || '';
+          const [orderRes, tripRes] = await Promise.all([
+              fetch(`/api/orders/${orderId}`, { headers: { 'Authorization': 'Bearer ' + token }}),
+              fetch(`/api/orders/${orderId}/next-trip`, { headers: { 'Authorization': 'Bearer ' + token }})
+          ]);
+          if (orderRes.ok) {
+              const data = await orderRes.json();
+              document.querySelector('input[name="customerName"]').value = data.customerName || '';
+              document.querySelector('input[name="customerMobile"]').value = data.customerMobile || '';
+              document.querySelector('textarea[name="address"]').value = data.fullAddress || '';
+          }
+          if (tripRes.ok) {
+              const tripData = await tripRes.json();
+              document.querySelector('input[name="tripNo"]').value = tripData.nextTripNo || '';
+          } else {
+              document.querySelector('input[name="tripNo"]').value = '';
+          }
       });
 
       const form = document.querySelector('form');

--- a/backend/src/test/java/com/easyreach/backend/service/ReceiptPdfServiceTest.java
+++ b/backend/src/test/java/com/easyreach/backend/service/ReceiptPdfServiceTest.java
@@ -47,6 +47,8 @@ public class ReceiptPdfServiceTest {
             assertTrue(text.contains("Consumer Copy"));
             assertTrue(text.contains("Driver Copy"));
             assertTrue(text.contains(d.orderId));
+            assertTrue(text.contains("Consumer Name"));
+            assertTrue(text.contains("Consumer Mobile"));
             assertTrue(text.contains("Khandyam"));
             assertTrue(text.contains("10.0Tons"));
             assertTrue(text.contains("18.4060366,83.9543993 Thank you"));

--- a/backend/src/test/java/com/easyreach/backend/service/ReceiptServiceImplTest.java
+++ b/backend/src/test/java/com/easyreach/backend/service/ReceiptServiceImplTest.java
@@ -53,6 +53,7 @@ class ReceiptServiceImplTest {
     void createSavesReceiptWithDefaults() {
         ReceiptDto dto = ReceiptDto.builder()
                 .orderId("ord1")
+                .sandQuantity("10")
                 .dispatchDateTime(LocalDateTime.now())
                 .driverName("Drv")
                 .driverMobile("222")
@@ -64,7 +65,6 @@ class ReceiptServiceImplTest {
                 .orderId("ORD1")
                 .customerName("Cust")
                 .customerMobile("111")
-                .sandQuantity("5")
                 .supplyPoint("SP")
                 .fullAddress("Addr")
                 .tripNo(0)
@@ -76,6 +76,7 @@ class ReceiptServiceImplTest {
         Receipt saved = service.create(dto);
 
         assertEquals("ORD1", saved.getOrderId());
+        assertEquals("10", saved.getSandQuantity());
         assertEquals("SP", saved.getSupplyPoint());
         assertEquals("18.4060366,83.9543993 Thank you", saved.getFooterLine());
         assertEquals("test-user", saved.getCreatedBy());
@@ -91,7 +92,7 @@ class ReceiptServiceImplTest {
                 .tripNo("T1")
                 .customerName("Name")
                 .customerMobile("111")
-                .sandQuantity("5")
+                .sandQuantity("10")
                 .supplyPoint("SP")
                 .dispatchDateTime(LocalDateTime.now())
                 .driverName("D")


### PR DESCRIPTION
## Summary
- Drop sand quantity from orders so it can vary per receipt
- Accept sand quantity when creating receipts and use it for PDFs
- Update forms, service, and tests for receipt-level sand quantity
- Use a fixed dropdown for sand quantity on the receipt form
- Get next trip number from backend instead of incrementing in the browser
- Rename receipt customer labels to consumer name/mobile

## Testing
- `mvn -q -pl backend test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd5e44330832db339cb84a8b403cf