### PR TITLE
Add home screen with navigation links

### DIFF
--- a/backend/src/main/java/com/easyreach/backend/controller/HomeController.java
+++ b/backend/src/main/java/com/easyreach/backend/controller/HomeController.java
@@ -1,0 +1,13 @@
+package com.easyreach.backend.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String home() {
+        return "home";
+    }
+}

--- a/backend/src/main/resources/templates/home.html
+++ b/backend/src/main/resources/templates/home.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Home</title>
+</head>
+<body class="container py-5">
+<h2 class="mb-4">Home</h2>
+<div class="d-flex flex-column gap-3">
+    <button id="orderBtn" class="btn btn-primary">Order Save</button>
+    <button id="receiptBtn" class="btn btn-success">Generate Bill</button>
+</div>
+<script>
+ document.addEventListener('DOMContentLoaded', function () {
+    const token = localStorage.getItem('jwt');
+    if (!token) {
+        const redirect = encodeURIComponent(window.location.pathname + window.location.search);
+        window.location.href = `/login?redirect=${redirect}`;
+        return;
+    }
+    const loadPage = async (url) => {
+        const res = await fetch(url, { headers: { 'Authorization': 'Bearer ' + token }});
+        if (res.ok) {
+            const html = await res.text();
+            document.open();
+            document.write(html);
+            document.close();
+        }
+    };
+    document.getElementById('orderBtn').addEventListener('click', () => loadPage('/orders/new'));
+    document.getElementById('receiptBtn').addEventListener('click', () => loadPage('/receipts/new'));
+ });
+</script>
+</body>
+</html>

--- a/backend/src/main/resources/templates/login.html
+++ b/backend/src/main/resources/templates/login.html
@@ -22,7 +22,7 @@
 </form>
 <script>
 const params = new URLSearchParams(window.location.search);
-const redirectUrl = params.get('redirect') || '/receipts/new';
+const redirectUrl = params.get('redirect') || '/';
 const form = document.getElementById('loginForm');
 form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -49,7 +49,7 @@ form.addEventListener('submit', async (e) => {
             document.write(html);
             document.close();
         } else {
-            document.getElementById('loginError').textContent = 'Unable to load receipt form';
+            document.getElementById('loginError').textContent = 'Unable to load page';
         }
     } catch (err) {
         document.getElementById('loginError').textContent = 'Login failed';

--- a/backend/src/main/resources/templates/orders/order_form.html
+++ b/backend/src/main/resources/templates/orders/order_form.html
@@ -7,6 +7,7 @@
     <title>Create Order</title>
 </head>
 <body class="container py-4">
+<button id="homeBtn" class="btn btn-secondary mb-3">Home</button>
 <h2 class="mb-3">Create Order</h2>
 <form id="orderForm">
     <div class="mb-3">
@@ -46,6 +47,17 @@
     }
     const form = document.getElementById('orderForm');
     const messageEl = document.getElementById('message');
+    const homeBtn = document.getElementById('homeBtn');
+
+    homeBtn.addEventListener('click', async () => {
+        const res = await fetch('/', { headers: { 'Authorization': 'Bearer ' + token }});
+        if (res.ok) {
+            const html = await res.text();
+            document.open();
+            document.write(html);
+            document.close();
+        }
+    });
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
         messageEl.textContent = '';

--- a/backend/src/main/resources/templates/receipts/receipt_form.html
+++ b/backend/src/main/resources/templates/receipts/receipt_form.html
@@ -7,6 +7,7 @@
     <title>Create Receipt</title>
 </head>
 <body class="container py-4">
+<button id="homeBtn" class="btn btn-secondary mb-3">Home</button>
 <h2 class="mb-3">Create Receipt</h2>
 <form th:action="@{/receipts}" method="post">
     <div class="mb-3">
@@ -71,6 +72,17 @@
           return;
       }
       const orderSelect = document.getElementById('orderSelect');
+      const homeBtn = document.getElementById('homeBtn');
+
+      homeBtn.addEventListener('click', async () => {
+          const res = await fetch('/', { headers: { 'Authorization': 'Bearer ' + token }});
+          if (res.ok) {
+              const html = await res.text();
+              document.open();
+              document.write(html);
+              document.close();
+          }
+      });
       orderSelect.addEventListener('change', async () => {
           const orderId = orderSelect.value;
           if (!orderId) return;


### PR DESCRIPTION
## Summary
- Implement simple `HomeController` and Home page to route authenticated users to order or receipt forms
- Redirect login to new home page and add mobile-friendly navigation buttons across templates
- Include Home button in order and receipt forms for easy navigation

## Testing
- `cd backend && mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf5e57538832da291caef8b96939d