### PR TITLE
Send 401 on invalid JWTs

### DIFF
--- a/backend/src/main/java/com/easyreach/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/easyreach/backend/security/JwtAuthenticationFilter.java
@@ -67,6 +67,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     log.debug("Authentication successful for user {} company {}", identifier, companyId);
                 } else {
                     log.warn("Token validation failed for user {}", identifier);
+                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                    return;
                 }
             }
             chain.doFilter(request, response);


### PR DESCRIPTION
## Summary
- Return HTTP 401 immediately when JWT validation fails so clients can redirect to login

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68be066b6f58832d900e07383ecc6935